### PR TITLE
coveralls.io internal server error handling

### DIFF
--- a/src/main/scala/CoverallsPlugin.scala
+++ b/src/main/scala/CoverallsPlugin.scala
@@ -156,8 +156,10 @@ trait AbstractCoverallsPlugin  {
     val res = coverallsClient.postFile(coverallsFile)
     if(res.error) {
       currState.log.error("Uploading to coveralls.io failed: " + res.message)
-      if(res.message.contains("Build processing error")) {
+      if(res.message.contains(CoverallsClient.buildErrorString)) {
         currState.log.error("The error message 'Build processing error' can mean your repo token is incorrect. See https://github.com/lemurheavy/coveralls-public/issues/46")
+      } else if (res.message.contains(CoverallsClient.serverErrorString)) {
+        currState.log.error("Coveralls.io server internal error")
       }
       currState.fail
     } else {


### PR DESCRIPTION
At time of writing, coveralls.io is [suffering from connectivity issues](https://twitter.com/CoverallsApp/statuses/444365955766837248). In this case Coveralls plugin is failing with JSON parsing error (see https://travis-ci.org/levkhomich/akka-tracing/jobs/20885510). This pull request fixes the problem by explicitly handling response code 500 with corresponding server message.
