### PR TITLE
Updated Specifying Your Repo Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add the following to your `build.sbt`. The path can be absolute and point to som
 Just remember: **Do not store repo tokens inside your project if it is in a public git repository!**
 
 ```scala
-import com.github.theon.coveralls.CoverallsPlugin.CoverallsKeys._
+import CoverallsPlugin.CoverallsKeys._
 
 coverallsTokenFile := "/path/to/my/repo/token.txt"
 ```
@@ -97,7 +97,7 @@ coverallsTokenFile := "/path/to/my/repo/token.txt"
 **Do not store repo tokens inside your project if it is in a public git repository!**
 
 ```scala
-import com.github.theon.coveralls.CoverallsPlugin.CoverallsKeys._
+import CoverallsPlugin.CoverallsKeys._
 
 coverallsToken := "my-token"
 ```


### PR DESCRIPTION
I tested it only with scala 2.10.4 and sbt 0.13, but import with fully qualified name didn't work.
But simple import `import CoverallsPlugin.CoverallsKeys._` works perfectly.

So this should be changed in docs.
