### PR TITLE
Updated ciphers for the October 2015 https://coveralls.io cert.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 jdk: 
   - openjdk6
+  - oraclejdk8
 scala: 
   - 2.10.5
 script:

--- a/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
@@ -84,6 +84,9 @@ class OpenJdkSafeSsl extends SSLSocketFactory {
     "TLS_RSA_WITH_AES_128_CBC_SHA",
     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
     "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
     "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
     "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
     "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
@@ -95,7 +98,7 @@ class OpenJdkSafeSsl extends SSLSocketFactory {
     "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
     "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
     "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
-  )
+  ) intersect SSLSocketFactory.getDefault.asInstanceOf[SSLSocketFactory].getSupportedCipherSuites
 
   def getDefaultCipherSuites = Array.empty
 

--- a/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
@@ -1,13 +1,16 @@
 package com.github.theon.coveralls
 
 import java.io.File
+import java.net.HttpURLConnection
 
 import com.fasterxml.jackson.core.JsonEncoding
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
-import org.scoverage.coveralls.CoverallsClient
+import org.scoverage.coveralls.{ OpenJdkSafeSsl, CoverallsClient }
 
 import scala.io.Codec
 import scala.util.Try
+import scalaj.http.Http
+import scalaj.http.HttpOptions._
 
 class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers {
 
@@ -53,6 +56,22 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
         assert(attemptAtResponse.get.message == "Couldn't find a repository matching this job.")
         assert(attemptAtResponse.get.error)
 
+      }
+    }
+  }
+
+  "OpenJdkSafeSsl" when {
+    "connecting to " + CoverallsClient.url should {
+      "connect using ssl" in {
+        val openJdkSafeSsl = new OpenJdkSafeSsl
+        val request = Http.get(CoverallsClient.url)
+          .option(connTimeout(60000))
+          .option(readTimeout(60000))
+          .option(sslSocketFactory(openJdkSafeSsl))
+
+        request.process { conn: HttpURLConnection =>
+          conn.getResponseCode should equal(404)
+        }
       }
     }
   }


### PR DESCRIPTION
Added a test for `OpenJdkSafeSsl` against https://coverals.io.
Testing Travis on both the existing `openjdk6` and now `oraclejdk8`.
Either of the ECDSA ciphers seem to fix JDK8 alone, but cross referenced ciphers mentioned in:
- https://www.ssllabs.com/ssltest/analyze.html?d=coveralls.io
- http://hg.openjdk.java.net/jdk6/jdk6/jdk/file/bb7457f945ea/src/share/classes/sun/security/ssl/CipherSuite.java