### PR TITLE
Add support for CircleCI CI_PULL_REQUEST parameter

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -36,6 +36,7 @@ class CoverallPayloadWriter(
     writeOpt("repo_token", repoToken)
     writeOpt("service_name", serviceName)
     writeOpt("service_job_id", travisJobId)
+    writeOpt("service_pull_request", sys.env.get("CI_PULL_REQUEST"))
 
     addGitInfo
 


### PR DESCRIPTION
If this build is part of a pull request, CircleCI sets the
[`CI_PULL_REQUEST` environment variable][0] to its URL.  When this
envrionment variable is set, the URL should be provided to Coveralls via
the [`service_pull_request` API post parameter][1].

This change checks for `CI_PULL_REQUEST`, and if set, includes it in the
API call as `service_pull_request`.

[0]: https://circleci.com/changelog/20141019T213802Z
[1]: https://coveralls.zendesk.com/hc/en-us/articles/201770395