### PR TITLE
Fix coveralls publishing

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -3,7 +3,6 @@ package org.scoverage.coveralls
 import xml.{ Node, XML }
 import scala.io.{ Codec, Source }
 import java.io.File
-
 /**
  * The file will replace the original CoberturaReader
  */
@@ -40,12 +39,15 @@ class CoberturaMultiSourceReader(coberturaFile: File, sourceDirs: Seq[File], enc
    */
   private def sourceFilesRelative: Set[String] = reportXML \\ "class" \\ "@filename" map (_.toString()) toSet
 
-  def sourceFiles: Set[File] = for {
-    relativePath <- sourceFilesRelative
-    sourceDir <- sourceDirs
-    //only one directory contains the file
-    sourceFile = new File(sourceDir, relativePath) if sourceFile.exists
-  } yield sourceFile
+  def sourceFiles: Set[File] = {
+    for {
+      relativePath <- sourceFilesRelative
+      sourceDir <- sourceDirs
+      //only one directory contains the file
+      sourceFile = new File(sourceDir, relativePath)
+      if sourceFile.exists
+    } yield sourceFile
+  }
 
   def sourceFilenames = sourceFiles.map(_.getCanonicalPath)
 

--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -8,6 +8,7 @@ import annotation.tailrec
 import com.fasterxml.jackson.core.{ JsonFactory, JsonEncoding }
 
 class CoverallPayloadWriter(
+    projectRootDir: File,
     coverallsFile: File,
     repoToken: Option[String],
     travisJobId: Option[String],
@@ -17,6 +18,7 @@ class CoverallPayloadWriter(
     jsonEnc: JsonEncoding
 ) {
 
+  val projectRootDirStr = projectRootDir.toString + "/"
   import gitClient._
 
   val gen = generator(coverallsFile)
@@ -87,8 +89,13 @@ class CoverallPayloadWriter(
   }
 
   def addSourceFile(report: SourceFileReport) {
+
+    // create a name relative to the project root (rather than the module root)
+    // this is needed so that coveralls can find the file in git.
+    val fileName = report.file.replace(projectRootDirStr, "")
+
     gen.writeStartObject()
-    gen.writeStringField("name", report.fileRel)
+    gen.writeStringField("name", fileName)
 
     val source = Source.fromFile(report.file)(sourcesEnc)
     val sourceCode = source.getLines().mkString("\n")

--- a/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
@@ -24,7 +24,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
   }
 
   def coverallsWriter(writer: Writer, tokenIn: Option[String], travisJobIdIn: Option[String], serviceName: Option[String], enc: Codec) =
-    new CoverallPayloadWriter(new File(""), tokenIn, travisJobIdIn, serviceName, testGitClient, enc, JsonEncoding.UTF8) {
+    new CoverallPayloadWriter(new File("").getAbsoluteFile, new File(""), tokenIn, travisJobIdIn, serviceName, testGitClient, enc, JsonEncoding.UTF8) {
       override def generator(file: File) = {
         val factory = new JsonFactory()
         factory.createGenerator(writer)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.0.2"


### PR DESCRIPTION
I believe this fixes the multiple project coveralls issues.
Two changes, 

1) Include the multi-module source roots
2) Change the relative path to be project rather than module relative in the coveralls upload.

I'm sure there is more that could be done but this appears to address the obvious issues.