### PR TITLE
Coveralls endpoint support (Issue #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ Add an environment variable `COVERALLS_REPO_TOKEN`, for example:
 
     export COVERALLS_REPO_TOKEN=my-token
 
+## Specifying Your Coveralls Endpoint
+
+If you're using https://coveralls.io as your endpoint, then you don't need to set this option. If you're using a hosted (enterprise) instance of coveralls, you will need to specify your endpoint in one of two ways.
+
+### Put your endpoint directly in your `build.sbt`
+
+```scala
+import org.scoverage.coveralls.Imports.CoverallsKeys._
+
+coverallsEndpoint := Some("http://my-instance.com")
+```
+
+### Add an environment variable
+
+Add an environment variable `COVERALLS_ENDPOINT`, for example:
+
+    export COVERALLS_ENDPOINT=http://my-instance.com
+
 ## Custom Source File Encoding
 
 By default `sbt-coveralls` assumes your source files are `UTF-8` encoded. To use a different encoding, add the following to your `build.sbt`

--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -15,8 +15,7 @@ class CoverallPayloadWriter(
     serviceName: Option[String],
     gitClient: GitClient,
     sourcesEnc: Codec,
-    jsonEnc: JsonEncoding
-) {
+    jsonEnc: JsonEncoding) {
 
   val projectRootDirStr = projectRootDir.toString + "/"
   import gitClient._

--- a/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
@@ -10,11 +10,12 @@ import java.net.{ HttpURLConnection, Socket, InetAddress }
 import com.fasterxml.jackson.core.JsonEncoding
 import com.fasterxml.jackson.databind.ObjectMapper
 
-class CoverallsClient(httpClient: HttpClient, sourcesEnc: Codec, jsonEnc: JsonEncoding) {
+class CoverallsClient(endpoint: String, httpClient: HttpClient, sourcesEnc: Codec, jsonEnc: JsonEncoding) {
 
   import CoverallsClient._
 
   val mapper = newMapper
+  def url = s"$endpoint/api/v1/jobs"
 
   def newMapper = {
     val mapper = new ObjectMapper
@@ -43,7 +44,6 @@ class CoverallsClient(httpClient: HttpClient, sourcesEnc: Codec, jsonEnc: JsonEn
 }
 
 object CoverallsClient {
-  val url = "https://coveralls.io/api/v1/jobs"
   val tokenErrorString = "Couldn't find a repository matching this job"
   val errorResponseTitleTag = "title"
   val defaultErrorMessage = "ERROR (no title found)"

--- a/src/main/scala/org/scoverage/coveralls/GitClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/GitClient.scala
@@ -14,8 +14,7 @@ object GitClient {
     authorEmail: String,
     committerName: String,
     committerEmail: String,
-    shortMessage: String
-  )
+    shortMessage: String)
 }
 
 class GitClient(cwd: String)(implicit log: Logger) {

--- a/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
@@ -14,12 +14,14 @@ import scalaj.http.HttpOptions._
 
 class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers {
 
+  val defaultEndpoint = "https://coveralls.io"
+
   "CoverallsClient" when {
     "making API call" should {
 
       "return a valid response for success" in {
         val testHttpClient = new TestSuccessHttpClient()
-        val coverallsClient = new CoverallsClient(testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
 
         val response = coverallsClient.postFile(new File("src/test/resources/TestSourceFile.scala"))
 
@@ -31,7 +33,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
 
       "return a valid response with Korean for success" in {
         val testHttpClient = new TestSuccessHttpClient()
-        val coverallsClient = new CoverallsClient(testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
 
         val response = coverallsClient.postFile(new File("src/test/resources/TestSourceFileWithKorean.scala"))
 
@@ -46,7 +48,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
           500,
           """{"message":"Couldn't find a repository matching this job.","error":true}"""
         )
-        val coverallsClient = new CoverallsClient(testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
 
         val attemptAtResponse = Try {
           coverallsClient.postFile(new File("src/test/resources/TestSourceFileWithKorean.scala"))
@@ -57,14 +59,22 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
         assert(attemptAtResponse.get.error)
 
       }
+
+      "use the endpoint to build the url" in {
+        val testHttpClient = new TestSuccessHttpClient()
+        val coverallsClient = new CoverallsClient("https://test.endpoint", testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        
+        assert(coverallsClient.url == "https://test.endpoint/api/v1/jobs")
+      }
     }
   }
 
   "OpenJdkSafeSsl" when {
-    "connecting to " + CoverallsClient.url should {
+    val url = "https://coveralls.io/api/v1/jobs"
+    "connecting to " + url should {
       "connect using ssl" in {
         val openJdkSafeSsl = new OpenJdkSafeSsl
-        val request = Http.get(CoverallsClient.url)
+        val request = Http.get(url)
           .option(connTimeout(60000))
           .option(readTimeout(60000))
           .option(sslSocketFactory(openJdkSafeSsl))

--- a/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
@@ -63,7 +63,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
       "use the endpoint to build the url" in {
         val testHttpClient = new TestSuccessHttpClient()
         val coverallsClient = new CoverallsClient("https://test.endpoint", testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
-        
+
         assert(coverallsClient.url == "https://test.endpoint/api/v1/jobs")
       }
     }


### PR DESCRIPTION
Addresses issue #74 by adding support for specifying the Coveralls endpoint. This is needed for enterprise editions of Coveralls. Currenltly, `sbt-coveralls` assumes that you want to upload coverage results to `coveralls.io`. This PR simply allows you to change that value.