### PR TITLE
Updating `isChild` method to use `sbt.IO.relativize` to avoid issue #73

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -3,6 +3,7 @@ package org.scoverage.coveralls
 import xml.{ Node, XML }
 import scala.io.{ Codec, Source }
 import java.io.File
+import sbt.IO
 /**
  * The file will replace the original CoberturaReader
  */
@@ -25,12 +26,7 @@ class CoberturaMultiSourceReader(coberturaFile: File, sourceDirs: Seq[File], enc
    *         the file tree rooted at parent.
    *         It returns true if child and parent points to the same directory
    */
-  def isChild(child: File, parent: File): Boolean = {
-    child != null && parent != null && parent.isDirectory && {
-      child.getCanonicalPath == parent.getCanonicalPath ||
-        isChild(child.getParentFile, parent)
-    }
-  }
+  def isChild(child: File, parent: File): Boolean = IO.relativize(parent, child).isDefined
 
   val reportXML = XML.loadFile(coberturaFile)
 

--- a/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -42,7 +42,7 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
 
   "CoberturaMultiSourceReader" should {
     "correctly determine who is parent file and who is child file" in {
-      reader.isChild(srcFoo, srcFoo) shouldBe true
+      reader.isChild(srcFoo, srcFoo) shouldBe false
       reader.isChild(srcBarFoo, srcFoo) shouldBe false
       reader.isChild(srcFoo, srcBarFoo) shouldBe false
       reader.isChild(srcFoo, root) shouldBe true


### PR DESCRIPTION
Fixes issue #73 "Source directories must not be nested" error.