### PR TITLE
Add missing `coverageReport` command in multiproject documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
   [as a separate command](https://github.com/scoverage/sbt-scoverage#multi-project-reports)
 
     script:
-      - sbt clean coverage test &&
+      - sbt clean coverage coverageReport test &&
         sbt coverageAggregate
     after_success:
       - sbt coveralls


### PR DESCRIPTION
I just got bitten by this and felt it was worth fixing the doc.
`coverageAggregate` produces nothing if `coverageReport` has not been executed before, and that in turn makes `coveralls` fail.