### PR TITLE
Update scalaj-http to 1.1.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ publishArtifact in Test := false
 
 pomIncludeRepository := { _ => false }
 
-scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
+scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
 
 dependencyOverrides ++= Set(
   "com.jcraft"                        %  "jsch"                        % "0.1.51"
@@ -24,9 +24,7 @@ libraryDependencies ++= Seq (
   // DO NOT UPGRADE: later versions of jgit use Java 7 and we still need to support Java 6
   "org.eclipse.jgit"                  %  "org.eclipse.jgit"            % "3.7.0.201502260915-r",
   //"org.eclipse.jgit"                  %  "org.eclipse.jgit"            % "4.0.1.201506240215-r",
-// major version change - needs more investigation/testing
-//  "org.scalaj"                        %% "scalaj-http"                 % "1.1.4",
-  "org.scalaj"                        %% "scalaj-http"                 % "0.3.16",
+  "org.scalaj"                        %% "scalaj-http"                 % "1.1.4",
   "org.mockito"                       %  "mockito-core"                % "1.10.19"       % "test",
   "org.scalatest"                     %% "scalatest"                   % "2.2.5"         % "test"
 )

--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -2,6 +2,7 @@ package org.scoverage.coveralls
 
 import xml.{ Node, XML }
 import scala.io.{ Codec, Source }
+import scala.language.postfixOps
 import java.io.File
 /**
  * The file will replace the original CoberturaReader

--- a/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
@@ -15,7 +15,7 @@ class CoverallsClient(endpoint: String, httpClient: HttpClient, sourcesEnc: Code
   import CoverallsClient._
 
   val mapper = newMapper
-  def url = s"$endpoint/api/v1/jobs"
+  def url: String = s"$endpoint/api/v1/jobs"
 
   def newMapper = {
     val mapper = new ObjectMapper
@@ -62,16 +62,15 @@ class ScalaJHttpClient extends HttpClient {
   val openJdkSafeSsl = new OpenJdkSafeSsl
 
   def multipart(url: String, name: String, filename: String, mime: String, data: Array[Byte]): CoverallHttpResponse = try {
-    val request = Http.multipart(url, MultiPart(name, filename, mime, data))
+    val request = Http(url).postMulti(MultiPart(name, filename, mime, data))
       .option(connTimeout(60000))
       .option(readTimeout(60000))
       .option(sslSocketFactory(openJdkSafeSsl))
 
-    request.process { conn: HttpURLConnection =>
-      CoverallHttpResponse(conn.getResponseCode, Http.tryParse(conn.getInputStream, Http.readString))
-    }
+    val response = request.execute()
+    CoverallHttpResponse(response.code, response.body)
   } catch {
-    case e: HttpException => CoverallHttpResponse(500, e.body)
+    case e: HttpException => CoverallHttpResponse(500, e.message)
   }
 }
 

--- a/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
@@ -74,14 +74,14 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
     "connecting to " + url should {
       "connect using ssl" in {
         val openJdkSafeSsl = new OpenJdkSafeSsl
-        val request = Http.get(url)
+        val request = Http(url)
+          .method("GET")
           .option(connTimeout(60000))
           .option(readTimeout(60000))
           .option(sslSocketFactory(openJdkSafeSsl))
 
-        request.process { conn: HttpURLConnection =>
-          conn.getResponseCode should equal(404)
-        }
+        val response = request.execute()
+        response.code should equal(404)
       }
     }
   }


### PR DESCRIPTION
This PR updates `scalaj-http` to `1.1.4` and fixes very minor issue around `feature imports` in `CoberturaMultiSourceReader `.

Tested using existing unit-tests and manually for one of the repositories by adding custom resolver for this updated build and testing coveralls report on travis.