### PR TITLE
do not validate DTD on loading coverage file

### DIFF
--- a/src/test/resources/test_cobertura_multisource_with_dtd.xml
+++ b/src/test/resources/test_cobertura_multisource_with_dtd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://somewherethatdoesnotexist/xml/coverage-04.dtd">
+<coverage line-rate="0.87">
+    <packages>
+        <package line-rate="0.87" name="com.github.theon.coveralls">
+            <classes>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar/foo/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar/foo/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="foo/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="3" hits="1"/>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -52,6 +52,14 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
       //catches mistakes with substrings
       reader.isChild(new File(root, "srcB-2.10"), srcFoo) shouldBe false
     }
+
+    "ignore the dtd" in {
+      val dtdReader = new CoberturaMultiSourceReader(
+        new File(root, "test_cobertura_multisource_with_dtd.xml"),
+        Seq(srcBarFoo, srcFoo),
+        Codec("UTF-8")
+      )
+    }
   }
 
   "CoberturaMultiSourceReader" should {


### PR DESCRIPTION
Currently, sourceforge is down so the plugin is unable to load the dtd.
This puts a dependency that is isn't completely necessary.