### PR TITLE
Don't Validate Document DTDs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ dependencyOverrides ++= Set(
   "com.jcraft"                        %  "jsch"                        % "0.1.51"
 )
 
-crossSbtVersions := Vector("0.13.16", "1.0.0")
+crossSbtVersions := Vector("0.13.16", "1.0.2")
 
 libraryDependencies ++= Seq (
   "com.fasterxml.jackson.core"        %  "jackson-core"                % "2.9.0",

--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -1,6 +1,6 @@
 package org.scoverage.coveralls
 
-import xml.{ Node, XML }
+import xml.Node
 import scala.io.{ Codec, Source }
 import scala.language.postfixOps
 import java.io.File
@@ -32,7 +32,7 @@ class CoberturaMultiSourceReader(coberturaFile: File, sourceDirs: Seq[File], enc
     childPath != parentPath && childPath.startsWith(parentPath)
   }
 
-  val reportXML = XML.loadFile(coberturaFile)
+  val reportXML: xml.Elem = XmlHelper.loadXmlFile(coberturaFile)
 
   /**
    * A sequence of source files paths that are relative to some source directory

--- a/src/main/scala/org/scoverage/coveralls/CoberturaReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaReader.scala
@@ -1,12 +1,12 @@
 package org.scoverage.coveralls
 
-import xml.{ Node, XML }
+import xml.Node
 import scala.io.{ Codec, Source }
 import java.io.File
 
 class CoberturaReader(coberturaFile: File, childProjectRoot: File, rootProject: File, enc: Codec) {
 
-  val elem = XML.loadFile(coberturaFile)
+  val elem: xml.Elem = XmlHelper.loadXmlFile(coberturaFile)
 
   val rootProjectDir = rootProject.getAbsolutePath + File.separator
   val childProjectDir = childProjectRoot.getAbsolutePath + File.separator

--- a/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
@@ -6,7 +6,7 @@ import scalaj.http.{ MultiPart, Http }
 import scalaj.http.HttpOptions._
 import java.io.File
 import javax.net.ssl.{ SSLSocket, SSLSocketFactory }
-import java.net.{ HttpURLConnection, Socket, InetAddress }
+import java.net.{ Socket, InetAddress }
 import com.fasterxml.jackson.core.JsonEncoding
 import com.fasterxml.jackson.databind.ObjectMapper
 

--- a/src/main/scala/org/scoverage/coveralls/XmlHelper.scala
+++ b/src/main/scala/org/scoverage/coveralls/XmlHelper.scala
@@ -1,0 +1,36 @@
+package org.scoverage.coveralls
+
+import java.io.{ File, FileInputStream }
+import javax.xml.parsers.SAXParserFactory
+
+import org.xml.sax.InputSource
+
+import scala.util.Try
+import scala.xml.XML
+
+/**
+ *  A simple utility around XML.loadXml that doesn't depend on external DTD fetching and processing. This avoids
+ *  random failures when coburtura.xml DTD clauses point to dead domains
+ */
+object XmlHelper {
+
+  private[this] val factory: SAXParserFactory = locally {
+    val f = SAXParserFactory.newInstance()
+    f.setValidating(false)
+    f.setFeature("http://xml.org/sax/features/validation", false)
+    f.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false)
+    f.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    f
+  }
+
+  def loadXmlFile(file: File): xml.Elem = {
+    val parser = factory.newSAXParser()
+    val stream = new FileInputStream(file)
+    try {
+      XML.loadXML(new InputSource(stream), parser)
+    } finally {
+      Try(stream.close())
+    }
+  }
+
+}

--- a/src/test/resources/test_cobertura_dtd.xml
+++ b/src/test/resources/test_cobertura_dtd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://localhost:1/xml/coverage-04.dtd">
+<coverage line-rate="0.87">
+    <packages>
+        <package line-rate="0.87" name="com.github.theon.coveralls">
+            <classes>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar/foo/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar/foo/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="foo/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="3" hits="1"/>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -41,6 +41,16 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
   }
 
   "CoberturaMultiSourceReader" should {
+
+    "not blow up when DTD documents can't be fetched" in {
+      val withoutDTD = new CoberturaMultiSourceReader(
+        new File(root, "test_cobertura_dtd.xml"),
+        Seq(srcBarFoo, srcFoo),
+        Codec("UTF-8")
+      )
+      withoutDTD.reportXML shouldEqual reader.reportXML
+    }
+
     "correctly determine who is parent file and who is child file" in {
       reader.isChild(srcFoo, srcFoo) shouldBe false
       reader.isChild(srcBarFoo, srcFoo) shouldBe false

--- a/src/test/scala/com/github/theon/coveralls/XmlHelperTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/XmlHelperTest.scala
@@ -1,0 +1,28 @@
+package com.github.theon.coveralls
+
+import java.io.File
+
+import org.scalatest.{ Matchers, WordSpec }
+import org.scoverage.coveralls.XmlHelper
+
+import scala.xml.XML
+
+class XmlHelperTest extends WordSpec with Matchers {
+
+  val root = new File(getClass.getResource("/").getFile)
+
+  val invalidDTD = new File(root, "test_cobertura_dtd.xml")
+
+  "XmlHelper" when {
+
+    "parsing XML documents with an invalid DTD" should {
+
+      "not attempt to fetch the DTD and successfully parse" in {
+        XmlHelper.loadXmlFile(invalidDTD) shouldBe an[xml.Elem]
+        // Verify the document actually has an unusable DTD
+        assertThrows[java.net.ConnectException](XML.loadFile(invalidDTD))
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
Drop DTD fetching from the XML parser and set crossSbtVersion to use SBT 1.0.2.

This PR is meant to accomplish the same thing as https://github.com/scoverage/sbt-coveralls/pull/97 but differs in that it:
- does not attempt to validate DTD at all
- addresses the issue in both `CoberturaMultiSourceReader` AND `CoberturaReader`