### PR TITLE
#105 SBT cross compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
 
 sudo: false
 
+# build with coverage
+script:
+  - sbt ^test
+
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,13 @@ dependencyOverrides ++= Set(
   "com.jcraft"                        %  "jsch"                        % "0.1.51"
 )
 
-crossSbtVersions := Vector("0.13.16", "1.0.2")
+crossSbtVersions := List("0.13.16", "1.0.2")
+
+scalaVersion := (CrossVersion partialVersion sbtCrossVersion.value match {
+  case Some((0, 13)) => "2.10.6"
+  case Some((1, _))  => "2.12.3"
+  case _             => sys error s"Unhandled sbt version ${sbtCrossVersion.value}"
+})
 
 libraryDependencies ++= Seq (
   "com.fasterxml.jackson.core"        %  "jackson-core"                % "2.9.0",
@@ -76,3 +82,5 @@ releaseProcess := Seq[ReleaseStep](
   setNextVersion,
   commitNextVersion,
   pushChanges)
+
+val sbtCrossVersion = sbtVersion in pluginCrossBuild


### PR DESCRIPTION
This should sort out cross compilation. 

In case you wanted to cross compile with different `sbt` versions use: `^compile` like here:

```
[pdolega@maracuja sbt-coveralls]$ sbt ^compile
[info] Loading global plugins from /home/pdolega/.sbt/0.13/plugins
[info] Loading project definition from /home/pdolega/projects/ReactSphere-2018/sbt-coveralls/project
[info] Set current project to sbt-coveralls (in build file:/home/pdolega/projects/ReactSphere-2018/sbt-coveralls/)
[info] Setting `sbtVersion in pluginCrossBuild` to 0.13.16
[info] Set current project to sbt-coveralls (in build file:/home/pdolega/projects/ReactSphere-2018/sbt-coveralls/)
[success] Total time: 0 s, completed Mar 12, 2018 5:01:55 PM
[info] Setting `sbtVersion in pluginCrossBuild` to 1.0.2
[info] Set current project to sbt-coveralls (in build file:/home/pdolega/projects/ReactSphere-2018/sbt-coveralls/)
[success] Total time: 0 s, completed Mar 12, 2018 5:01:55 PM
[info] Setting `sbtVersion in pluginCrossBuild` to 0.13.16
[info] Set current project to sbt-coveralls (in build file:/home/pdolega/projects/ReactSphere-2018/sbt-coveralls/)
```