### PR TITLE
File paths relative to git repo root

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -8,7 +8,7 @@ import annotation.tailrec
 import com.fasterxml.jackson.core.{ JsonFactory, JsonEncoding }
 
 class CoverallPayloadWriter(
-    projectRootDir: File,
+    repoRootDir: File,
     coverallsFile: File,
     repoToken: Option[String],
     travisJobId: Option[String],
@@ -17,7 +17,7 @@ class CoverallPayloadWriter(
     sourcesEnc: Codec,
     jsonEnc: JsonEncoding) {
 
-  val projectRootDirStr = projectRootDir.getCanonicalPath.replace(File.separator, "/") + "/"
+  val repoRootDirStr = repoRootDir.getCanonicalPath.replace(File.separator, "/") + "/"
   import gitClient._
 
   val gen = generator(coverallsFile)
@@ -91,7 +91,7 @@ class CoverallPayloadWriter(
 
     // create a name relative to the project root (rather than the module root)
     // this is needed so that coveralls can find the file in git.
-    val fileName = report.file.replace(projectRootDirStr, "")
+    val fileName = report.file.replace(repoRootDirStr, "")
 
     gen.writeStartObject()
     gen.writeStringField("name", fileName)

--- a/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
@@ -78,13 +78,15 @@ object CoverallsPlugin extends AutoPlugin {
 
     val coverallsClient = new CoverallsClient(endpoint, apiHttpClient, sourcesEnc, jsonEnc)
 
+    val repoRootDirectory = new File(coverallsGitRepoLocation.value getOrElse ".")
+
     val writer = new CoverallPayloadWriter(
-      baseDirectory.value,
+      repoRootDirectory,
       coverallsFile.value,
       repoToken,
       travisJobIdent,
       coverallsServiceName.value,
-      new GitClient(coverallsGitRepoLocation.value getOrElse ".")(log),
+      new GitClient(repoRootDirectory)(log),
       sourcesEnc,
       jsonEnc
     )

--- a/src/main/scala/org/scoverage/coveralls/GitClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/GitClient.scala
@@ -18,7 +18,7 @@ object GitClient {
     shortMessage: String)
 }
 
-class GitClient(cwd: String)(implicit log: Logger) {
+class GitClient(cwd: File)(implicit log: Logger) {
 
   import scala.collection.JavaConverters._
 

--- a/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
@@ -14,7 +14,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
 
   implicit val log = ConsoleLogger(System.out)
 
-  val testGitClient = new GitClient(".") {
+  val testGitClient = new GitClient(new File(".")) {
     override def remotes = List("remote")
     override def remoteUrl(remoteName: String) = "remoteUrl"
     override def currentBranch = "branch"

--- a/src/test/scala/com/github/theon/coveralls/GitClientTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/GitClientTest.scala
@@ -37,7 +37,7 @@ class GitClientTest extends WordSpec with BeforeAndAfterAll with Matchers {
       .setMessage("Commit message for unit test")
       .call()
 
-    git = new GitClient(repoDir.getAbsolutePath)
+    git = new GitClient(repoDir)
   }
 
   "GitClient" when {


### PR DESCRIPTION
All file paths must be relative to git repository root, not project root in case they are different (see https://github.com/scoverage/sbt-coveralls/issues/54), in other words when `coverallsGitRepoLocation` setting value is different than `Some(".")`.