### PR TITLE
Send source file content MD5 digest instead of the content itself

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -1,6 +1,7 @@
 package org.scoverage.coveralls
 
 import java.io.File
+import java.security.MessageDigest
 import scala.io.{ Codec, Source }
 
 import sbt.Logger
@@ -100,7 +101,9 @@ class CoverallPayloadWriter(
     val sourceCode = source.getLines().mkString("\n")
     source.close()
 
-    gen.writeStringField("source", sourceCode)
+    val sourceDigest = CoverallPayloadWriter.md5.digest(sourceCode.getBytes).map("%02X" format _).mkString
+
+    gen.writeStringField("source_digest", sourceDigest)
 
     gen.writeFieldName("coverage")
     gen.writeStartArray()
@@ -122,4 +125,10 @@ class CoverallPayloadWriter(
   def flush(): Unit = {
     gen.flush()
   }
+}
+
+object CoverallPayloadWriter {
+
+  val md5: MessageDigest = MessageDigest.getInstance("MD5")
+
 }

--- a/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
@@ -76,7 +76,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
         coverallsW.flush()
 
         w.toString should equal(
-          """{"name":"src/test/resources/TestSourceFile.scala","source":"/**\n * Test Scala Source File that is 10 lines\n */\nclass TestSourceFile {\n\n\n\n\n\n}","coverage":[1,null,2]}"""
+          """{"name":"src/test/resources/TestSourceFile.scala","source_digest":"A420A88E114B1CB1272F5984F333C75C","coverage":[1,null,2]}"""
         )
       }
 


### PR DESCRIPTION
According to https://coveralls.zendesk.com/hc/en-us/articles/201774865-API-Introduction only MD5 hash needs to be sent for every source file.

I found another, earlier version of Coveralls API document - https://coveralls.zendesk.com/hc/en-us/articles/201350799-API-Reference.
There was information about sending the full source in some cases. Now it's gone.