### PR TITLE
Determine source files encoding the same way `sbt-scoverage` plugin does

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ By default `sbt-coveralls` uses the currently checked-out branch for reporting. 
 
 ## Custom Source File Encoding
 
-By default `sbt-coveralls` assumes your source files are `UTF-8` encoded. To use a different encoding, add the following to your `build.sbt`
+`sbt-coveralls` finds the encoding in `scalacOptions` setting value.
+If not defined it assumes source files are encoded using platform-specific encoding.
+To specify encoding, add the following to your `build.sbt`
 
 ```scala
-import org.scoverage.coveralls.Imports.CoverallsKeys._
-
-encoding := "ISO-8859-1"
+scalacOptions += Seq("-encoding", "UTF-8")
 ```
 
 Once the plugin has slurped your source code into memory using the specified encoding, it will be converted into UTF-8 to be sent to the coveralls API. This is because the coveralls API uses a JSON request body and RFC 4627 mandates that [JSON must be UTF encoded](http://tools.ietf.org/html/rfc4627#section-3).

--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -1,11 +1,11 @@
 package org.scoverage.coveralls
 
 import xml.Node
-import scala.io.{ Codec, Source }
+import scala.io.Source
 import scala.language.postfixOps
 import java.io.File
 
-class CoberturaMultiSourceReader(coberturaFile: File, sourceDirs: Seq[File], enc: Codec) {
+class CoberturaMultiSourceReader(coberturaFile: File, sourceDirs: Seq[File], sourceEncoding: Option[String]) {
 
   require(sourceDirs.nonEmpty, "Given empty sequence of source directories")
 
@@ -84,7 +84,10 @@ class CoberturaMultiSourceReader(coberturaFile: File, sourceDirs: Seq[File], enc
   }
 
   def reportForSource(source: String) = {
-    val fileSrc = Source.fromFile(source)(enc)
+    val fileSrc = sourceEncoding match {
+     case Some(enc) => Source.fromFile(source, enc)
+     case None => Source.fromFile(source)
+    }
     val lineCount = fileSrc.getLines().size
     fileSrc.close()
 

--- a/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -5,8 +5,6 @@ import java.io.{ FileNotFoundException, File }
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import org.scoverage.coveralls.{ CoberturaMultiSourceReader }
 
-import scala.io.Codec
-
 class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll with Matchers {
 
   val root = new File(getClass.getResource("/").getFile)
@@ -19,7 +17,7 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
   val reader = new CoberturaMultiSourceReader(
     new File(root, "test_cobertura_multisource.xml"),
     Seq(srcBarFoo, srcFoo),
-    Codec("UTF-8")
+    Some("UTF-8")
   )
 
   "CoberturaMultiSourceReader" when {
@@ -45,7 +43,7 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
       val withoutDTD = new CoberturaMultiSourceReader(
         new File(root, "test_cobertura_dtd.xml"),
         Seq(srcBarFoo, srcFoo),
-        Codec("UTF-8")
+        Some("UTF-8")
       )
       withoutDTD.reportXML shouldEqual reader.reportXML
     }
@@ -74,25 +72,25 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
 
     "complain when given an empty set of source diectories" in {
       intercept[IllegalArgumentException] {
-        new CoberturaMultiSourceReader(new File(""), Seq(), Codec("UTF-8"))
+        new CoberturaMultiSourceReader(new File(""), Seq(), Some("UTF-8"))
       }
     }
 
     "complain when al least two of the source directories are nested" in {
       intercept[IllegalArgumentException] {
-        new CoberturaMultiSourceReader(new File(""), Seq(srcBarFoo, srcFoo, root), Codec("UTF-8"))
+        new CoberturaMultiSourceReader(new File(""), Seq(srcBarFoo, srcFoo, root), Some("UTF-8"))
       }
     }
 
     "complain when given a non-existing cobertura file" in {
       intercept[FileNotFoundException] {
-        new CoberturaMultiSourceReader(new File("zzz"), Seq(root), Codec("UTF-8"))
+        new CoberturaMultiSourceReader(new File("zzz"), Seq(root), Some("UTF-8"))
       }
     }
 
     "complain when given am incorrect cobertura file" in {
       intercept[Exception] {
-        new CoberturaMultiSourceReader(fileBarFoo, Seq(root), Codec("UTF-8"))
+        new CoberturaMultiSourceReader(fileBarFoo, Seq(root), Some("UTF-8"))
       }
     }
 

--- a/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallPayloadWriterTest.scala
@@ -2,13 +2,11 @@ package com.github.theon.coveralls
 
 import java.io.{ File, StringWriter, Writer }
 
-import com.fasterxml.jackson.core.{ JsonEncoding, JsonFactory }
+import com.fasterxml.jackson.core.JsonFactory
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import org.scoverage.coveralls.GitClient.GitRevision
 import org.scoverage.coveralls.{ CoverallPayloadWriter, GitClient, SourceFileReport }
 import sbt.ConsoleLogger
-
-import scala.io.Codec
 
 class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Matchers {
 
@@ -23,8 +21,8 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
     }
   }
 
-  def coverallsWriter(writer: Writer, tokenIn: Option[String], travisJobIdIn: Option[String], serviceName: Option[String], enc: Codec) =
-    new CoverallPayloadWriter(new File("").getAbsoluteFile, new File(""), tokenIn, travisJobIdIn, serviceName, testGitClient, enc, JsonEncoding.UTF8) {
+  def coverallsWriter(writer: Writer, tokenIn: Option[String], travisJobIdIn: Option[String], serviceName: Option[String], enc: Option[String]) =
+    new CoverallPayloadWriter(new File("").getAbsoluteFile, new File(""), tokenIn, travisJobIdIn, serviceName, enc, testGitClient) {
       override def generator(file: File) = {
         val factory = new JsonFactory()
         factory.createGenerator(writer)
@@ -38,7 +36,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
 
       "generate a correct starting payload with travis job id" in {
         val w = new StringWriter()
-        val coverallsW = coverallsWriter(w, Some("testRepoToken"), Some("testTravisJob"), Some("travis-ci"), Codec("UTF-8"))
+        val coverallsW = coverallsWriter(w, Some("testRepoToken"), Some("testTravisJob"), Some("travis-ci"), Some("UTF-8"))
 
         coverallsW.start
         coverallsW.flush()
@@ -52,7 +50,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
 
       "generate a correct starting payload without travis job id" in {
         val w = new StringWriter()
-        val coverallsW = coverallsWriter(w, Some("testRepoToken"), None, None, Codec("UTF-8"))
+        val coverallsW = coverallsWriter(w, Some("testRepoToken"), None, None, Some("UTF-8"))
 
         coverallsW.start
         coverallsW.flush()
@@ -66,7 +64,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
 
       "add source files correctly" in {
         val w = new StringWriter()
-        val coverallsW = coverallsWriter(w, Some("testRepoToken"), None, Some("travis-ci"), Codec("UTF-8"))
+        val coverallsW = coverallsWriter(w, Some("testRepoToken"), None, Some("travis-ci"), Some("UTF-8"))
 
         val projectRoot = new File("").getAbsolutePath.replace(File.separator, "/") + "/"
 
@@ -82,7 +80,7 @@ class CoverallPayloadWriterTest extends WordSpec with BeforeAndAfterAll with Mat
 
       "end the file correctly" in {
         val w = new StringWriter()
-        val coverallsW = coverallsWriter(w, Some("testRepoToken"), None, Some("travis-ci"), Codec("UTF-8"))
+        val coverallsW = coverallsWriter(w, Some("testRepoToken"), None, Some("travis-ci"), Some("UTF-8"))
 
         coverallsW.start
         coverallsW.end()

--- a/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoverallsClientTest.scala
@@ -3,11 +3,9 @@ package com.github.theon.coveralls
 import java.io.File
 import java.net.HttpURLConnection
 
-import com.fasterxml.jackson.core.JsonEncoding
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import org.scoverage.coveralls.{ OpenJdkSafeSsl, CoverallsClient }
 
-import scala.io.Codec
 import scala.util.Try
 import scalaj.http.Http
 import scalaj.http.HttpOptions._
@@ -21,7 +19,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
 
       "return a valid response for success" in {
         val testHttpClient = new TestSuccessHttpClient()
-        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient)
 
         val response = coverallsClient.postFile(new File("src/test/resources/TestSourceFile.scala"))
 
@@ -33,7 +31,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
 
       "return a valid response with Korean for success" in {
         val testHttpClient = new TestSuccessHttpClient()
-        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient)
 
         val response = coverallsClient.postFile(new File("src/test/resources/TestSourceFileWithKorean.scala"))
 
@@ -48,7 +46,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
           500,
           """{"message":"Couldn't find a repository matching this job.","error":true}"""
         )
-        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient(defaultEndpoint, testHttpClient)
 
         val attemptAtResponse = Try {
           coverallsClient.postFile(new File("src/test/resources/TestSourceFileWithKorean.scala"))
@@ -62,7 +60,7 @@ class CoverallsClientTest extends WordSpec with BeforeAndAfterAll with Matchers 
 
       "use the endpoint to build the url" in {
         val testHttpClient = new TestSuccessHttpClient()
-        val coverallsClient = new CoverallsClient("https://test.endpoint", testHttpClient, Codec.UTF8, JsonEncoding.UTF8)
+        val coverallsClient = new CoverallsClient("https://test.endpoint", testHttpClient)
 
         assert(coverallsClient.url == "https://test.endpoint/api/v1/jobs")
       }


### PR DESCRIPTION
Deprecate `coverallsEncoding` key.

`sbt-scoverage` plugin, which is used in tandem with `sbt-coveralls` finds the encoding in `scalacOptions` setting, the same way `scalac` does.

There is no point in introducing separate setting just for `sbt-coveralls` plugin.

To define encoding add this line to your build file:

```scala
scalacOptions += Seq("-encoding", "UTF-8")
```

or add "-encoding", "UTF-8" pair to other scalacOptions if you already have this setting.
