### PR TITLE
Improve performance for a large cobertura XML

### DIFF
--- a/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/com/github/theon/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -34,6 +34,14 @@ class CoberturaMultiSourceReaderTest extends WordSpec with BeforeAndAfterAll wit
           List(None, None, Some(1), Some(1), Some(1), None, None, None, None, None)
         )
       }
+
+      "return a valid SourceFileReport instance if there are some classes which have the same @filename" in {
+        val fileReport = reader.reportForSource(fileBarFoo.getCanonicalPath)
+        fileReport.file should endWith("bar/foo/TestSourceFile.scala")
+        fileReport.lineCoverage should equal(
+          List(None, None, None, Some(1), Some(1), Some(2), None, None, Some(1), Some(1))
+        )
+      }
     }
   }
 


### PR DESCRIPTION
When a cobertura XML is too large, The `\\` operation like `reportXML \\ "class"` takes  too much time. So I reduced to use `\\`. To upload a JSON to coveralls had taken about 120 minutes if a cobertura XML is about 50MB.  By this patch it will be done in  4 minutes.