### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ target/
 *.ipr
 *.iws
 .idea/
+.bloop/
+.metals/
+metals.sbt
 
 .settings/
 .cache

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Join the chat at https://gitter.im/scoverage/sbt-coveralls](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scoverage/sbt-coveralls?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scoverage/sbt-coveralls/badge.svg?kill_cache=1)](https://search.maven.org/artifact/org.scoverage/sbt-coveralls/)
 
-SBT plugin that uploads scala code coverage to [https://coveralls.io](https://coveralls.io) and integrates with [Travis CI](#travis-ci-integration). This plugin uses [scoverage](https://github.com/scoverage/scalac-scoverage-plugin/) to generate the code coverage metrics.
+SBT plugin that uploads scala code coverage to [https://coveralls.io](https://coveralls.io) and integrates with [Travis CI](#travis-ci-integration) and [GitHub Actions](#github-actions-integration). This plugin uses [scoverage](https://github.com/scoverage/scalac-scoverage-plugin/) to generate the code coverage metrics.
 
 For an example project that uses this plugin [click here](https://github.com/scoverage/sbt-scoverage-samples).
 For example output [click here](https://coveralls.io/r/scoverage/scoverage-samples)
@@ -32,19 +32,53 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
 1) Add the following to your `travis.yml`
 
-       script: "sbt clean coverage test"
-       after_success: "sbt coverageReport coveralls"
+    ```yaml
+    script: "sbt clean coverage test"
+    after_success: "sbt coverageReport coveralls"
+    ```
 
    If you have a multi-module project, perform `coverageAggregate`
    [as a separate command](https://github.com/scoverage/sbt-scoverage#multi-project-reports)
 
-       script:
-         - sbt clean coverage test coverageReport &&
-           sbt coverageAggregate
-       after_success:
-         - sbt coveralls
+    ```yaml
+    script:
+      - sbt clean coverage test coverageReport &&
+        sbt coverageAggregate
+    after_success:
+      - sbt coveralls
+    ```
 
 2) Job done! Commit these changes to `travis.yml` to kick off your Travis build and you should see coverage reports appear on https://coveralls.io/
+
+## GitHub Actions Integration
+
+`sbt-coveralls` can be run by [GitHub Actions](https://github.com/features/actions) by following these instructions:
+
+1) Add the following to your `.github/workflows/ci.yml`
+
+    ```yaml
+    - name: Run tests
+      run: sbt clean coverage test
+
+    - name: Upload coverage data to Coveralls
+      run: sbt coverageReport coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
+    ```
+
+    If you have a multi-module project, perform `coverageAggregate`
+    [as a separate command](https://github.com/scoverage/sbt-scoverage#multi-project-reports)
+
+    ```yaml
+    - name: Upload coverage data to Coveralls
+      run: sbt coverageAggregate coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
+    ```
+
+2) Job done! Commit these changes to kick off your GitHub Actions build and you should see coverage reports appear on https://coveralls.io/
 
 ## Manual Usage
 

--- a/src/main/scala/org/scoverage/coveralls/CIService.scala
+++ b/src/main/scala/org/scoverage/coveralls/CIService.scala
@@ -1,0 +1,34 @@
+package org.scoverage.coveralls
+
+import scala.io.Source
+import scala.util.parsing.json.{JSON, JSONObject}
+
+trait CIService {
+  def name: String
+  def jobId: Option[String]
+  def pullRequest: Option[String]
+  def currentBranch: Option[String]
+}
+
+case object TravisCI extends CIService {
+  def name = "travis-ci"
+  def jobId = sys.env.get("TRAVIS_JOB_ID")
+  def pullRequest = sys.env.get("CI_PULL_REQUEST")
+
+  def currentBranch = sys.env.get("CI_BRANCH")
+}
+
+case object GitHubActions extends CIService {
+  def name = "github"
+  def jobId = sys.env.get("GITHUB_RUN_ID")
+
+  // https://github.com/coverallsapp/github-action/blob/master/src/run.ts#L31-L40
+  def pullRequest = for {
+    eventName <- sys.env.get("GITHUB_EVENT_NAME") if eventName == "pull_request"
+    payloadPath <- sys.env.get("GITHUB_EVENT_PATH")
+    payload <- JSON.parseRaw(Source.fromFile(payloadPath, "utf-8").mkString)
+    prNumber <- payload.asInstanceOf[JSONObject].obj.get("number")
+  } yield prNumber.toString
+
+  def currentBranch = sys.env.get("GITHUB_REF")
+}

--- a/src/main/scala/org/scoverage/coveralls/GitClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/GitClient.scala
@@ -55,8 +55,7 @@ class GitClient(cwd: File)(implicit log: Logger) {
     storedConfig.getString("remote", remoteName, "url")
   }
 
-  def currentBranch: String =
-    sys.env.getOrElse("CI_BRANCH", repository.getBranch)
+  def currentBranch: String = repository.getBranch
 
   def lastCommit(): GitRevision = {
     val git = new Git(repository)


### PR DESCRIPTION
This PR generalizes support for CI services other than Travis and provides an implementation for GitHub Actions. The specific implementation was taken by reading the implementations of [coverallsapp/github-action](https://github.com/coverallsapp/github-action) and [nickmerwin/node-coveralls](https://github.com/nickmerwin/node-coveralls) to provide an experience similar to the official GitHub Action.

Besides unit tests, I tested this by publishing a snapshot and testing it on [this branch of PureConfig](https://github.com/pureconfig/pureconfig/tree/coverage-in-github-actions-2), which publishes coverage using both Travis and GitHub Actions. You can compare the results of the [Travis job](https://coveralls.io/builds/32127607) vs the [GitHub Actions job](https://coveralls.io/builds/32127531) (we have non-deterministic tests, so actual coverage is not expected to match exactly).

Closes #126.