### PR TITLE
Fix default location for cobertura file

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
@@ -55,7 +55,7 @@ object CoverallsPlugin extends AutoPlugin {
       else None
     },
     coverallsFile := crossTarget.value / "coveralls.json",
-    coberturaFile := crossTarget.value / "scoverage-data" / "coverage-report" / "cobertura.xml",
+    coberturaFile := crossTarget.value / "coverage-report" / "cobertura.xml",
     coverallsGitRepoLocation := Some(".")
   )
 


### PR DESCRIPTION
![default][]

## What/Why?

* Fix for #224
* Make sure `sbt-coveralls` uses the correct default location
  for the cobertura file

[default]: https://media.giphy.com/media/OSnMRw2DzK989jiUK6/giphy.gif