### PR TITLE
Target JDK 1.8 for generated artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val root = Project("sbt-coveralls", file("."))
   .settings(
     Test / publishArtifact := false,
     scalacOptions := Seq(
+      "-release:8",
       "-unchecked",
       "-deprecation",
       "-feature",


### PR DESCRIPTION
This should allow this sbt plugin to be used where JDK 1.8 is still being used.

Resolves: https://github.com/scoverage/sbt-coveralls/issues/250