### PR TITLE
Use JDK 8 for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   scala:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        JDK: [ 8, 17 ]
 
     steps:
       - name: checkout the repo
@@ -18,10 +21,11 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v14
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          java-version: "openjdk@1.17.0"
+          java-version: ${{ matrix.JDK }}
+          distribution: temurin
 
       - name: run tests
         run: sbt generateXMLFiles test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,11 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '8'
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-


### PR DESCRIPTION
Not sure why the `-release:8` scalac flag didn't work when releasing a new version but one way to enforce JDK 8 compatibility is to just use JDK8 when releasing.

Also since we are building against JDK 8, I added it to the normal CI to make sure we don't break JDK 8 compatiblity