### PR TITLE
Downgrade jgit due to jdk 8 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val root = Project("sbt-coveralls", file("."))
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % "2.14.2",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.2",
-      "org.eclipse.jgit" % "org.eclipse.jgit" % "6.5.0.202303070854-r",
+      "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.0.202109080827-r",
       "org.scalaj" %% "scalaj-http" % "2.4.2",
       "io.circe" %% "circe-core" % "0.14.5",
       "io.circe" %% "circe-generic" % "0.14.5",


### PR DESCRIPTION
It seems like the newer 6 version series of jgit is published against newer versions of JDK 8. `5.13.0.202109080827-r` is the latest version that still supports JDK 8. I verified that this solves the problem locally but if you want to confirm that this solves the JDK 8 issues then merge https://github.com/scoverage/sbt-coveralls/pull/252 and then rebase main ontop of this PR.