### PR TITLE
Pin scala steward to specific jgit version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,5 @@
+# Latest version of jgit which was compiled with JDK 8 which this project targets
+updates.pin = [{ groupId = "org.eclipse.jgit", version = "5.13.0.202109080827-r" }]
+updates.ignore = [
+  { groupId = "org.eclipse.jgit" }
+]


### PR DESCRIPTION
Adds a conf file for scala steward that will prevent it from making PR's to update jgit. Ths is done because jgit `5.13.0.202109080827-r` is the last version that was compiled with JDK 8 (see https://github.com/scoverage/sbt-coveralls/pull/253 for context).