### PR TITLE
Fix isChild check in CoberturaMultiSourceReader

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -41,8 +41,8 @@ class CoberturaMultiSourceReader(
     *   to the same directory
     */
   def isChild(child: File, parent: File): Boolean = {
-    val childPath = child.getCanonicalPath()
-    val parentPath = parent.getCanonicalPath()
+    val childPath = child.getCanonicalFile.toPath
+    val parentPath = parent.getCanonicalFile.toPath
     childPath != parentPath && childPath.startsWith(parentPath)
   }
 

--- a/src/test/resources/projectA/src/main/scala-2.12/bar/foo/TestSourceScala212.scala
+++ b/src/test/resources/projectA/src/main/scala-2.12/bar/foo/TestSourceScala212.scala
@@ -1,0 +1,5 @@
+package bar.foo
+
+class TestSourceScala212 {
+  val version = "2.12"
+}

--- a/src/test/resources/test_cobertura.xml.template
+++ b/src/test/resources/test_cobertura.xml.template
@@ -4,6 +4,7 @@
     <sources>
         <source>--source</source>
         <source>{{PWD}}/src/test/resources/projectA/arc/main/scala/</source>
+        <source>{{PWD}}/src/test/resources/projectA/arc/main/scala-2.12/</source>
         <source>{{PWD}}/src/test/resources/projectB/arc/main/scala</source>
     </sources>
     <packages>
@@ -23,6 +24,10 @@
                         <line number="9" hits="1"/>
                         <line number="10" hits="1"/>
                     </lines>
+                </class>
+                <class line-rate="0" name="TestSourceScala212" filename="bar/foo/TestSourceScala212.scala">
+                    <methods/>
+                    <lines/>
                 </class>
                 <class line-rate="0.87" name="TestSourceFile" filename="foo/TestSourceFile.scala">
                     <methods/>

--- a/src/test/resources/test_cobertura_dtd.xml.template
+++ b/src/test/resources/test_cobertura_dtd.xml.template
@@ -4,6 +4,7 @@
     <sources>
         <source>--source</source>
         <source>{{PWD}}/src/test/resources/projectA/src/main/scala/</source>
+        <source>{{PWD}}/src/test/resources/projectA/src/main/scala-2.12/</source>
         <source>{{PWD}}/src/test/resources/projectB/src/main/scala</source>
     </sources>
     <packages>
@@ -23,6 +24,10 @@
                         <line number="9" hits="1"/>
                         <line number="10" hits="1"/>
                     </lines>
+                </class>
+                <class line-rate="0" name="TestSourceScala212" filename="bar/foo/TestSourceScala212.scala">
+                    <methods/>
+                    <lines/>
                 </class>
                 <class line-rate="0.87" name="TestSourceFile" filename="foo/TestSourceFile.scala">
                     <methods/>

--- a/src/test/resources/test_cobertura_multisource.xml.template
+++ b/src/test/resources/test_cobertura_multisource.xml.template
@@ -2,6 +2,7 @@
     <sources>
         <source>--source</source>
         <source>{{PWD}}/src/test/resources/projectA/src/main/scala/</source>
+        <source>{{PWD}}/src/test/resources/projectA/src/main/scala-2.12/</source>
         <source>{{PWD}}/src/test/resources/projectB/src/main/scala</source>
     </sources>
     <packages>
@@ -21,6 +22,10 @@
                         <line number="9" hits="1"/>
                         <line number="10" hits="1"/>
                     </lines>
+                </class>
+                <class line-rate="0" name="TestSourceScala212" filename="bar/foo/TestSourceScala212.scala">
+                    <methods/>
+                    <lines/>
                 </class>
                 <class line-rate="0.87" name="TestSourceFile" filename="foo/TestSourceFile.scala">
                     <methods/>

--- a/src/test/scala/org/scoverage/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -16,9 +16,11 @@ class CoberturaMultiSourceReaderTest
   val resourceDir = Utils.mkFileFromPath(Seq(".", "src", "test", "resources"))
   val sourceDirA =
     Utils.mkFileFromPath(resourceDir, Seq("projectA", "src", "main", "scala"))
+  val sourceDirA212 =
+    Utils.mkFileFromPath(resourceDir, Seq("projectA", "src", "main", "scala-2.12"))
   val sourceDirB =
     Utils.mkFileFromPath(resourceDir, Seq("projectB", "src", "main", "scala"))
-  val sourceDirs = Seq(sourceDirA, sourceDirB)
+  val sourceDirs = Seq(sourceDirA, sourceDirA212, sourceDirB)
 
   val reader = new CoberturaMultiSourceReader(
     Utils.mkFileFromPath(resourceDir, Seq("test_cobertura_multisource.xml")),
@@ -34,6 +36,10 @@ class CoberturaMultiSourceReaderTest
           Utils.mkFileFromPath(
             sourceDirA,
             Seq("bar", "foo", "TestSourceFile.scala")
+          ),
+          Utils.mkFileFromPath(
+            sourceDirA212,
+            Seq("bar", "foo", "TestSourceScala212.scala")
           ),
           Utils.mkFileFromPath(sourceDirB, Seq("foo", "TestSourceFile.scala"))
         )
@@ -87,6 +93,18 @@ class CoberturaMultiSourceReaderTest
             Some(1),
             Some(1)
           )
+        )
+      }
+
+      "return a valid SourceFileReport instance if files are in version-specific source dirs" in {
+        val sourceFile = Utils.mkFileFromPath(
+          sourceDirA212,
+          Seq("bar", "foo", "TestSourceScala212.scala")
+        )
+        println(sourceFile.getCanonicalPath)
+        val fileReport = reader.reportForSource(sourceFile.getCanonicalPath)
+        fileReport.file should endWith(
+          Seq("foo", "TestSourceScala212.scala").mkString(File.separator)
         )
       }
     }


### PR DESCRIPTION
591ff35bcbbee51fa4d71e795053ee8e04c85444 changed `isChild` to compare absolute paths rather than relative ones. However, it did something else - changed the variables being compared from instances of `Path` to `String`s. While `startsWith` is defined in both types, their behavior is _not_ the same. `Path#startsWith` correctly determines if a path is a parent of another because it takes file path elements in consideration, while `String#startsWith` does prefix checks at a character level.

In real scenarios, this fails when using Scala version specific source folders like `src/main/scala` and `src/main/scala-2.12`, natively supported by SBT. They are sibling directories, but the current implementation incorrectly assumes them to be parent and children, respectively. On this PR we're fixing it by keeping usage of absolute paths while still using `Path`.

Added a unit test that correctly catches this error so that hopefully we don't get any regressions.