### PR TITLE
Fix auth token handing in GitHub Actions

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CoverallsAuth.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsAuth.scala
@@ -1,0 +1,24 @@
+package org.scoverage.coveralls
+
+import scala.io.Source
+import io.circe._
+import io.circe.parser
+import io.circe.generic.auto._
+
+/** The strategy to use when authenticating against Coveralls.
+  */
+sealed trait CoverallsAuth
+
+/** Auth strategy where a Coveralls-specific token is used. Works with every CI
+  * service.
+  */
+case class CoverallsRepoToken(token: String) extends CoverallsAuth
+
+/** Auth strategy where a token specific to the CI service is used, such as a
+  * GitHub token. Works on selected CI services supported by Coveralls.
+  */
+case class CIServiceToken(token: String) extends CoverallsAuth
+
+/** Auth strategy where no token is passed. This seems to work for Travis.
+  */
+case object NoTokenNeeded extends CoverallsAuth


### PR DESCRIPTION
Fixes #257. See discussion in the issue for context.

The solution to support both the old behavior and the buggy one introduced in #212 ended up becoming more difficult than expected. When someone passes only `COVERALLS_REPO_TOKEN`, it's not possible in general to know if the token passed was a CI service token (old sbt-coveralls behavior for GitHub Actions) or a Coveralls token (forced by the above PR) without asking the user to change some of their settings, which would end up being another breaking change.

In the end, I leveraged the fact that GitHub tokens [have identifiable prefixes](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/#identifiable-prefixes) to support both cases.

Tested this by publishing a snapshot of sbt-coveralls, [using it with PureConfig](https://github.com/pureconfig/pureconfig/commit/86e31673396850a880597741740fcd0a4dace6fa), confirming that GitHub CI jobs [were successful](https://github.com/pureconfig/pureconfig/actions/runs/5720305068) and checking [Coveralls results](https://coveralls.io/builds/61689161).
