### PR TITLE
Fix windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,21 @@ on:
 
 jobs:
   scala:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # remove when PR is finished, just to make sure we don't make regression
       matrix:
         JDK: [ 8, 17 ]
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Ignore line ending differences in git
+        if: contains(runner.os, 'windows')
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - name: checkout the repo
         uses: actions/checkout@v4
         with:

--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -114,7 +114,7 @@ class CoberturaMultiSourceReader(
 
   protected def lineCoverage(sourceFile: String) = {
     val filenamePath =
-      splitPath(new File(sourceFile))._2.replace(File.separator, "/")
+      splitPath(new File(sourceFile))._2
 
     lineCoverageMap(filenamePath)
   }
@@ -130,9 +130,7 @@ class CoberturaMultiSourceReader(
     val lineHitMap = lineCoverage(source)
     val fullLineHit = (0 until lineCount).map(i => lineHitMap.get(i + 1))
 
-    val sourceNormalized = source.replace(File.separator, "/")
-
-    SourceFileReport(sourceNormalized, fullLineHit.toList)
+    SourceFileReport(source, fullLineHit.toList)
   }
 }
 

--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -95,8 +95,7 @@ class CoverallPayloadWriter(
   }
 
   def addSourceFile(report: SourceFileReport) = {
-    val repoRootDirStr =
-      repoRootDir.getCanonicalPath.replace(File.separator, "/") + "/"
+    val repoRootDirStr = repoRootDir.getCanonicalPath + File.separator
 
     // create a name relative to the project root (rather than the module root)
     // this is needed so that coveralls can find the file in git.

--- a/src/sbt-test/prepare.sh
+++ b/src/sbt-test/prepare.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-for submodule_path in $(git submodule status | cut -c2- | cut -d\  -f2); do echo "gitdir: ${PWD}/.git/modules/${submodule_path}" > ${submodule_path}/.git; done

--- a/src/test/resources/generate.sh
+++ b/src/test/resources/generate.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-resources=src/test/resources
-for f in ${resources}/*.template; do cat ${f} | sed "s|{{PWD}}|${PWD}|" > ${resources}/$(basename ${f} .template); done

--- a/src/test/resources/test_cobertura.xml.windows.template
+++ b/src/test/resources/test_cobertura.xml.windows.template
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://localhost:1/xml/coverage-04.dtd">
+<coverage line-rate="0.87">
+    <sources>
+        <source>--source</source>
+        <source>{{PWD}}\src\test\resources\projectA\arc\main\scala</source>
+        <source>{{PWD}}\src\test\resources\projectA\arc\main\scala-2.12</source>
+        <source>{{PWD}}\src\test\resources\projectB\arc\main\scala</source>
+    </sources>
+    <packages>
+        <package line-rate="0.87" name="org.scoverage.coveralls">
+            <classes>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar\foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar\foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0" name="TestSourceScala212" filename="bar\foo\TestSourceScala212.scala">
+                    <methods/>
+                    <lines/>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="3" hits="1"/>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/resources/test_cobertura_corrupted.xml.windows.template
+++ b/src/test/resources/test_cobertura_corrupted.xml.windows.template
@@ -1,0 +1,1 @@
+corrupted file content

--- a/src/test/resources/test_cobertura_dtd.xml.windows.template
+++ b/src/test/resources/test_cobertura_dtd.xml.windows.template
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://localhost:1/xml/coverage-04.dtd">
+<coverage line-rate="0.87">
+    <sources>
+        <source>--source</source>
+        <source>{{PWD}}\src\test\resources\projectA\src\main\scala</source>
+        <source>{{PWD}}\src\test\resources\projectA\src\main\scala-2.12</source>
+        <source>{{PWD}}\src\test\resources\projectB\src\main\scala</source>
+    </sources>
+    <packages>
+        <package line-rate="0.87" name="org.scoverage.coveralls">
+            <classes>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar\foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar\foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0" name="TestSourceScala212" filename="bar\foo\TestSourceScala212.scala">
+                    <methods/>
+                    <lines/>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="3" hits="1"/>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/resources/test_cobertura_multisource.xml.windows.template
+++ b/src/test/resources/test_cobertura_multisource.xml.windows.template
@@ -1,0 +1,41 @@
+<coverage line-rate="0.87">
+    <sources>
+        <source>--source</source>
+        <source>{{PWD}}\src\test\resources\projectA\src\main\scala</source>
+        <source>{{PWD}}\src\test\resources\projectA\src\main\scala-2.12</source>
+        <source>{{PWD}}\src\test\resources\projectB\src\main\scala</source>
+    </sources>
+    <packages>
+        <package line-rate="0.87" name="org.scoverage.coveralls">
+            <classes>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar\foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="bar\foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0" name="TestSourceScala212" filename="bar\foo\TestSourceScala212.scala">
+                    <methods/>
+                    <lines/>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="foo\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="3" hits="1"/>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/scala/org/scoverage/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoverallPayloadWriterTest.scala
@@ -153,8 +153,15 @@ class CoverallPayloadWriterTest
         )
         payloadWriter.flush()
 
+        val separator = if (System.getProperty("os.name").startsWith("Windows"))
+          s"""${File.separator}\\""" // Backwards slash is a special character in JSON so it needs to be escaped
+        else
+          File.separator
+
+        val name = List(".","src","test","resources","projectA","src","main","scala","bar","foo","TestSourceFile.scala")
+          .mkString(separator)
         writer.toString should equal(
-          """{"name":"./src/test/resources/projectA/src/main/scala/bar/foo/TestSourceFile.scala","source_digest":"B77361233B09D69968F8C62491A5085F","coverage":[1,null,2]}"""
+          s"""{"name":"$name","source_digest":"B77361233B09D69968F8C62491A5085F","coverage":[1,null,2]}"""
         )
       }
 


### PR DESCRIPTION
Resolves: https://github.com/scoverage/sbt-coveralls/issues/294

This PR makes coveralls works under windows, it consists of 2 commits

* `Make tests portable so it runs on Windows`: Various changes to tests so that they can run properly on Windows (but no changes to core codebase)
* `Add windows support by removing POSIX line seperator normalization`: Actual changes to core codebase so that sbt-coveralls can run under windows plus adding windows to github actions CI for verification

The changes that needed to be done to tests are fairly mechanical (largely involving handling Windows file separators) with notable changes listed below
* Shell scripts (`generate.sh`/`prepare.sh`) have been replaced with equivalent implementations in build.sbt sbt's dsl which provides us Windows portability for free
* Windows equivalent xml template files (i.e. `.xml.template`) has been introduced as `.xml.windows.template`. The only difference is using `\` instead of `/`, there might have been smarter solutions to this but I kept it this way to keep it simple.

In regards to the actual fix, this involved removing the so called normilzations which involved replacing the Windows file separator with the POSIX one. I am not sure what the original intent of these "normalizations" were, but making all representations/serializations of paths consistently use `\` under Windows (and `/` under POSIX although this behaviour is unchanges) fixes all of the issues.

The only current issue is that the [ `ninesstack.nmesos.cli.CliSpec`](https://github.com/NinesStack/nmesos/blob/trunk/src/test/scala/ninesstack/nmesos/cli/CliSpec.scala#L20-L25) scripted sbt-test [fails](https://github.com/scoverage/sbt-coveralls/actions/runs/10886410611/job/30206347056?pr=323#step:6:199) because this external scala project itself doesn't appear to be portable on Windows. I don't know what the best course of action here is as that repo is external to this one, simplest solution might be to just update that project so that the test passes under windows which will automatically fix it here.