### PR TITLE
Update scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Scalafmt
+
+permissions: {}
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v3
+        with:
+          arguments: '--list --mode diff-ref=origin/main'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,12 @@
-version = "3.5.3"
+version = "3.8.3"
 runner.dialect = scala213
+
+project {
+  git = true
+  excludePaths = [
+    "glob:**/src/test/resources/projectA/src/main/scala/bar/foo/TestSourceFile.scala",
+    "glob:**/src/test/resources/projectA/src/main/scala/bar/foo/TestSourceFile2.scala",
+    "glob:**/src/test/resources/projectA/src/main/scala/bar/foo/TestSourceFileWithKorean.scala",
+    "glob:**/src/test/resources/projectB/src/main/scala/foo/TestSourceFile.scala"
+  ]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,11 @@ generateXMLFiles := {
   val dir = (Test / resourceDirectory).value
   val pwd = (run / baseDirectory).value
 
-  val template = if (System.getProperty("os.name").startsWith("Windows"))
-    ".xml.windows.template"
-  else
-    ".xml.template"
+  val template =
+    if (System.getProperty("os.name").startsWith("Windows"))
+      ".xml.windows.template"
+    else
+      ".xml.template"
 
   dir.listFiles { (_, name) => name.endsWith(template) }.foreach {
     templateFile =>
@@ -30,16 +31,20 @@ prepareScripted := {
   val pwd = (run / baseDirectory).value
 
   val submodules = "git submodule status" !! log
-  val submodulePaths = submodules.split('\n').map{x =>
+  val submodulePaths = submodules.split('\n').map { x =>
     x.split(" ")(2)
   }
 
-  submodulePaths.foreach{ subModulePath =>
+  submodulePaths.foreach { subModulePath =>
     val path = pwd / ".git" / "modules" / subModulePath
-    val pathFixedForWindows = if (System.getProperty("os.name").startsWith("Windows"))
-      path.absolutePath.replace(File.separator, "/") // Git under Windows uses / for path separator
-    else
-      path.absolutePath
+    val pathFixedForWindows =
+      if (System.getProperty("os.name").startsWith("Windows"))
+        path.absolutePath.replace(
+          File.separator,
+          "/"
+        ) // Git under Windows uses / for path separator
+      else
+        path.absolutePath
     val destination = file(subModulePath) / ".git"
     IO.delete(destination)
     IO.write(destination, s"gitdir: $pathFixedForWindows")

--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -11,10 +11,10 @@ class CoberturaMultiSourceReader(
     sourceEncoding: Option[String]
 )(implicit log: Logger) {
   log.debug(
-    s"sbt-coveralls: CobertaMultiSourceReader: coberturaFile: ${coberturaFile}"
+    s"sbt-coveralls: CobertaMultiSourceReader: coberturaFile: $coberturaFile"
   )
   log.debug(
-    s"sbt-coveralls: CobertaMultiSourceReader: sourceDirs: ${sourceDirs}"
+    s"sbt-coveralls: CobertaMultiSourceReader: sourceDirs: $sourceDirs"
   )
 
   require(sourceDirs.nonEmpty, "Given empty sequence of source directories")
@@ -69,10 +69,10 @@ class CoberturaMultiSourceReader(
 
   def sourceFiles: Set[File] = {
     log.debug(
-      s"sbt-coveralls: CobertaMultiSourceReader: sourceFiles: sourceFilesRelative: ${sourceFilesRelative}"
+      s"sbt-coveralls: CobertaMultiSourceReader: sourceFiles: sourceFilesRelative: $sourceFilesRelative"
     )
     log.debug(
-      s"sbt-coveralls: CobertaMultiSourceReader: sourceFiles: sourceDirs: ${sourceDirs}"
+      s"sbt-coveralls: CobertaMultiSourceReader: sourceFiles: sourceDirs: $sourceDirs"
     )
     val sfs = for {
       relativePath <- sourceFilesRelative
@@ -82,7 +82,7 @@ class CoberturaMultiSourceReader(
       if sourceFile.exists
     } yield sourceFile
     log.debug(
-      s"sbt-coveralls: CobertaMultiSourceReader: sourceFiles: sourceFiles: ${sfs}"
+      s"sbt-coveralls: CobertaMultiSourceReader: sourceFiles: sourceFiles: $sfs"
     )
     sfs
   }

--- a/src/main/scala/org/scoverage/coveralls/CoverallsAuth.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsAuth.scala
@@ -9,18 +9,16 @@ import io.circe.generic.auto._
   */
 sealed trait CoverallsAuth
 
-/** Auth strategy where a Coveralls-specific token is used. Works
-  * with every CI service.
+/** Auth strategy where a Coveralls-specific token is used. Works with every CI
+  * service.
   */
 case class CoverallsRepoToken(token: String) extends CoverallsAuth
 
-/** Auth strategy where a token specific to the CI service is used,
-  * such as a GitHub token. Works on selected CI services supported
-  * by Coveralls.
+/** Auth strategy where a token specific to the CI service is used, such as a
+  * GitHub token. Works on selected CI services supported by Coveralls.
   */
 case class CIServiceToken(token: String) extends CoverallsAuth
 
-/** Auth strategy where no token is passed. This seems to work
-  * for Travis.
+/** Auth strategy where no token is passed. This seems to work for Travis.
   */
 case object NoTokenNeeded extends CoverallsAuth

--- a/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
@@ -80,7 +80,7 @@ object CoverallsPlugin extends AutoPlugin {
 
     val coverallsAuthOpt = coverallsService.value match {
       case Some(ciService) => ciService.coverallsAuth(repoToken)
-      case None => repoToken.map(CoverallsRepoToken)
+      case None            => repoToken.map(CoverallsRepoToken)
     }
 
     val coverallsAuth = coverallsAuthOpt.getOrElse {
@@ -131,13 +131,13 @@ object CoverallsPlugin extends AutoPlugin {
     )
 
     val fileReports =
-      reader.sourceFilenames.par.map(reader.reportForSource(_)).seq
+      reader.sourceFilenames.par.map(reader.reportForSource).seq
 
     log.info(
       s"sbt-coveralls: Adding file reports to the coveralls file (${coverallsFile.value.getName}) ..."
     )
 
-    fileReports.foreach(writer.addSourceFile(_))
+    fileReports.foreach(writer.addSourceFile)
 
     writer.end()
 

--- a/src/main/scala/org/scoverage/coveralls/Utils.scala
+++ b/src/main/scala/org/scoverage/coveralls/Utils.scala
@@ -5,7 +5,7 @@ import java.io.File
 object Utils {
   def mkFileFromPath(path: Seq[String]): File = {
     require(path.nonEmpty, "path cannot be empty")
-    val (p :: ps) = path
+    val p :: ps = path
     mkFileFromPath(new File(p), ps)
   }
 

--- a/src/test/scala/org/scoverage/coveralls/CIServiceTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CIServiceTest.scala
@@ -24,7 +24,8 @@ class CIServiceTest extends AnyWordSpec with Matchers {
           |}
           |""".stripMargin
 
-        GitHubActions.getFromJson(lines, "numericField") shouldBe Some("123")       }
+        GitHubActions.getFromJson(lines, "numericField") shouldBe Some("123")
+      }
     }
 
     "getPrNumber" should {

--- a/src/test/scala/org/scoverage/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -17,7 +17,10 @@ class CoberturaMultiSourceReaderTest
   val sourceDirA =
     Utils.mkFileFromPath(resourceDir, Seq("projectA", "src", "main", "scala"))
   val sourceDirA212 =
-    Utils.mkFileFromPath(resourceDir, Seq("projectA", "src", "main", "scala-2.12"))
+    Utils.mkFileFromPath(
+      resourceDir,
+      Seq("projectA", "src", "main", "scala-2.12")
+    )
   val sourceDirB =
     Utils.mkFileFromPath(resourceDir, Seq("projectB", "src", "main", "scala"))
   val sourceDirs = Seq(sourceDirA, sourceDirA212, sourceDirB)
@@ -180,7 +183,7 @@ class CoberturaMultiSourceReaderTest
       val sourcePath = Seq("bar", "foo", "TestSourceFile.scala")
       val sourceFile = Utils.mkFileFromPath(sourceDirA, sourcePath)
       val (source, file) = reader.splitPath(sourceFile)
-      source shouldEqual sourceDirA.getCanonicalPath()
+      source shouldEqual sourceDirA.getCanonicalPath
       file shouldEqual sourcePath.mkString(File.separator)
     }
 

--- a/src/test/scala/org/scoverage/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoverallPayloadWriterTest.scala
@@ -33,12 +33,14 @@ class CoverallPayloadWriterTest
       writer: Writer,
       tokenIn: Option[String],
       service: Option[CIService],
-      parallel: Boolean,
+      parallel: Boolean
   ): (CoverallPayloadWriter, Writer) = {
     val payloadWriter = new CoverallPayloadWriter(
       new File(".").getAbsoluteFile,
       new File("."),
-      service.flatMap(_.coverallsAuth(tokenIn)).getOrElse(CoverallsRepoToken(tokenIn.get)),
+      service
+        .flatMap(_.coverallsAuth(tokenIn))
+        .getOrElse(CoverallsRepoToken(tokenIn.get)),
       service,
       parallel,
       testGitClient
@@ -72,10 +74,10 @@ class CoverallPayloadWriterTest
           false
         )
 
-        payloadWriter.start
+        payloadWriter.start()
         payloadWriter.flush()
 
-        println(writer.toString())
+        println(writer.toString)
 
         writer.toString should equal(
           """{"repo_token":"testRepoToken","service_name":"my-service","service_job_id":"testServiceJob","parallel":false,""" +
@@ -86,9 +88,14 @@ class CoverallPayloadWriterTest
 
       "generate a correct starting payload without a CI service" in {
         val (payloadWriter, writer) =
-          coverallsWriter(new StringWriter(), Some("testRepoToken"), None, false)
+          coverallsWriter(
+            new StringWriter(),
+            Some("testRepoToken"),
+            None,
+            false
+          )
 
-        payloadWriter.start
+        payloadWriter.start()
         payloadWriter.flush()
 
         writer.toString should equal(
@@ -116,7 +123,7 @@ class CoverallPayloadWriterTest
           false
         )
 
-        payloadWriter.start
+        payloadWriter.start()
         payloadWriter.flush()
 
         writer.toString should equal(
@@ -147,18 +154,31 @@ class CoverallPayloadWriterTest
         )
         payloadWriter.addSourceFile(
           SourceFileReport(
-            sourceFile.getPath(),
+            sourceFile.getPath,
             List(Some(1), None, Some(2))
           )
         )
         payloadWriter.flush()
 
-        val separator = if (System.getProperty("os.name").startsWith("Windows"))
-          s"""${File.separator}\\""" // Backwards slash is a special character in JSON so it needs to be escaped
-        else
-          File.separator
+        val separator =
+          if (System.getProperty("os.name").startsWith("Windows"))
+            s"""${File.separator}\\""" // Backwards slash is a special character in JSON so it needs to be escaped
+          else
+            File.separator
 
-        val name = List(".","src","test","resources","projectA","src","main","scala","bar","foo","TestSourceFile.scala")
+        val name = List(
+          ".",
+          "src",
+          "test",
+          "resources",
+          "projectA",
+          "src",
+          "main",
+          "scala",
+          "bar",
+          "foo",
+          "TestSourceFile.scala"
+        )
           .mkString(separator)
         writer.toString should equal(
           s"""{"name":"$name","source_digest":"B77361233B09D69968F8C62491A5085F","coverage":[1,null,2]}"""
@@ -173,16 +193,17 @@ class CoverallPayloadWriterTest
           false
         )
 
-        payloadWriter.start
+        payloadWriter.start()
         payloadWriter.end()
 
         writer.toString should endWith("]}")
       }
 
       "include parallel correctly" in {
-        val (payloadWriter, writer) = coverallsWriter(new StringWriter(), Some("testRepoToken"), None, true)
+        val (payloadWriter, writer) =
+          coverallsWriter(new StringWriter(), Some("testRepoToken"), None, true)
 
-        payloadWriter.start
+        payloadWriter.start()
         payloadWriter.flush()
 
         writer.toString should equal(

--- a/src/test/scala/org/scoverage/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoverallsClientTest.scala
@@ -12,10 +12,9 @@ import scalaj.http.Http
 import scalaj.http.HttpOptions._
 
 class CoverallsClientTest
-  extends AnyWordSpec
-  with BeforeAndAfterAll
-  with Matchers
-{
+    extends AnyWordSpec
+    with BeforeAndAfterAll
+    with Matchers {
   val projectDir = Utils.mkFileFromPath(Seq("."))
   val resourceDir =
     Utils.mkFileFromPath(projectDir, Seq("src", "test", "resources"))

--- a/src/test/scala/org/scoverage/coveralls/GitClientTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/GitClientTest.scala
@@ -38,7 +38,7 @@ class GitClientTest extends AnyWordSpec with BeforeAndAfterAll with Matchers {
     storedConfig.save()
     // Add and commit a file
     val readme = new File(repoDir, "README.md")
-    readme.createNewFile();
+    readme.createNewFile()
     gitRepo
       .add()
       .addFilepattern("README.md")

--- a/src/test/scala/org/scoverage/coveralls/HttpClientTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/HttpClientTest.scala
@@ -11,7 +11,7 @@ class HttpClientTestSuccess extends HttpClient {
       data: Array[Byte]
   ) = {
     dataIn = new String(data, "UTF-8")
-    new CoverallHttpResponse(
+    CoverallHttpResponse(
       200,
       """
       {
@@ -32,7 +32,7 @@ class HttpClientTestFailure extends HttpClient {
       mime: String,
       data: Array[Byte]
   ) = {
-    new CoverallHttpResponse(
+    CoverallHttpResponse(
       200,
       """
       {
@@ -52,6 +52,6 @@ case class HttpClientTestFake(status: Int, body: String) extends HttpClient {
       mime: String,
       data: Array[Byte]
   ) = {
-    new CoverallHttpResponse(status, body)
+    CoverallHttpResponse(status, body)
   }
 }


### PR DESCRIPTION
This PR does the following things

- Updates scalfamt to the latest version as well as applying `project.git = true`. Not only is this faster since it only applies scalafmt on diffed files (as determined by git) but its neccessary so that scalafmt doesn't format git submodules
  - Also adds specific source files which are sensitive to formatting explicitly to the `excludePaths` list. There are other solutions for this (such as using `format:off`/`format:on` in the source file) but this to me appears the least brittle when it comes to testing.
- Applies scalafmt and places this in its own separate commit so that it can optionally be ignored with `.git-blame-ignore-revs` in a future PR
- Adds a github workflow action that checks if the entire codebase is committed. This can be added as a branch check to essentially prevent merging of PR's that are not formatted. I personally find this the best quality of life way to enforce code formatting (as opposed to solutions such as formatting on commit)