### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+f37dea67f822eeaffb056552035a0ddb69522020


### PR DESCRIPTION
This PR adds https://github.com/scoverage/sbt-coveralls/commit/f37dea67f822eeaffb056552035a0ddb69522020 to a file called `.git-blame-ignore-revs` which users can optionally add onto their git blame ignore list.