### PR TITLE
Apply easy fixes/inspections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
 
 import java.io.File
 import scala.sys.process._
+
 lazy val generateXMLFiles =
   taskKey[Unit]("Generate XML files (for test)")
 generateXMLFiles := {

--- a/src/main/scala/org/scoverage/coveralls/CIService.scala
+++ b/src/main/scala/org/scoverage/coveralls/CIService.scala
@@ -1,9 +1,10 @@
 package org.scoverage.coveralls
 
-import scala.io.Source
 import io.circe._
 import io.circe.parser
 import io.circe.generic.auto._
+
+import scala.io.Source
 
 trait CIService {
   def name: String

--- a/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoberturaMultiSourceReader.scala
@@ -1,9 +1,8 @@
 package org.scoverage.coveralls
 
-// import scala.language.postfixOps
-import java.io.File
-
 import sbt.Logger
+
+import java.io.File
 
 class CoberturaMultiSourceReader(
     coberturaFile: File,
@@ -87,7 +86,7 @@ class CoberturaMultiSourceReader(
     sfs
   }
 
-  def sourceFilenames = sourceFiles.map(_.getCanonicalPath)
+  def sourceFilenames: Set[String] = sourceFiles.map(_.getCanonicalPath)
 
   /** Splits a path to a source file into two parts:
     *   1. the absolute path to source directory that contain this sourceFile 2.
@@ -112,14 +111,14 @@ class CoberturaMultiSourceReader(
     (prefix, relativePath)
   }
 
-  protected def lineCoverage(sourceFile: String) = {
+  protected def lineCoverage(sourceFile: String): Map[Int, Int] = {
     val filenamePath =
       splitPath(new File(sourceFile))._2
 
     lineCoverageMap(filenamePath)
   }
 
-  def reportForSource(source: String) = {
+  def reportForSource(source: String): SourceFileReport = {
     val fileSrc = sourceEncoding match {
       case Some(enc) => scala.io.Source.fromFile(source, enc)
       case None      => scala.io.Source.fromFile(source)

--- a/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallPayloadWriter.scala
@@ -1,11 +1,10 @@
 package org.scoverage.coveralls
 
+import com.fasterxml.jackson.core.{JsonEncoding, JsonFactory, JsonGenerator}
+import sbt.Logger
+
 import java.io.{File, FileInputStream}
 import java.security.{DigestInputStream, MessageDigest}
-
-import com.fasterxml.jackson.core.{JsonFactory, JsonEncoding}
-
-import sbt.Logger
 
 class CoverallPayloadWriter(
     repoRootDir: File,
@@ -17,18 +16,18 @@ class CoverallPayloadWriter(
 )(implicit log: Logger) {
   import gitClient._
 
-  val gen = generator(coverallsFile)
+  val gen: JsonGenerator = generator(coverallsFile)
 
-  def generator(file: File) = {
+  def generator(file: File): JsonGenerator = {
     if (!file.getParentFile.exists) file.getParentFile.mkdirs
     val factory = new JsonFactory
     factory.createGenerator(file, JsonEncoding.UTF8)
   }
 
-  def start() = {
+  def start(): Unit = {
     gen.writeStartObject()
 
-    def writeOpt(fieldName: String, holder: Option[String]) =
+    def writeOpt(fieldName: String, holder: Option[String]): Unit =
       holder foreach { gen.writeStringField(fieldName, _) }
 
     coverallsAuth match {
@@ -52,7 +51,7 @@ class CoverallPayloadWriter(
     gen.writeStartArray()
   }
 
-  private def addGitInfo() = {
+  private def addGitInfo(): Unit = {
     gen.writeFieldName("git")
     gen.writeStartObject()
 
@@ -85,7 +84,7 @@ class CoverallPayloadWriter(
     gen.writeEndObject()
   }
 
-  private def addGitRemotes(remotes: Seq[String]) = {
+  private def addGitRemotes(remotes: Seq[String]): Unit = {
     remotes.foreach(remote => {
       gen.writeStartObject()
       gen.writeStringField("name", remote)
@@ -94,7 +93,7 @@ class CoverallPayloadWriter(
     })
   }
 
-  def addSourceFile(report: SourceFileReport) = {
+  def addSourceFile(report: SourceFileReport): Unit = {
     val repoRootDirStr = repoRootDir.getCanonicalPath + File.separator
 
     // create a name relative to the project root (rather than the module root)

--- a/src/main/scala/org/scoverage/coveralls/CoverallsAuth.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsAuth.scala
@@ -1,23 +1,18 @@
 package org.scoverage.coveralls
 
-import scala.io.Source
-import io.circe._
-import io.circe.parser
-import io.circe.generic.auto._
-
 /** The strategy to use when authenticating against Coveralls.
   */
-sealed trait CoverallsAuth
+sealed trait CoverallsAuth extends Product with Serializable
 
 /** Auth strategy where a Coveralls-specific token is used. Works with every CI
   * service.
   */
-case class CoverallsRepoToken(token: String) extends CoverallsAuth
+final case class CoverallsRepoToken(token: String) extends CoverallsAuth
 
 /** Auth strategy where a token specific to the CI service is used, such as a
   * GitHub token. Works on selected CI services supported by Coveralls.
   */
-case class CIServiceToken(token: String) extends CoverallsAuth
+final case class CIServiceToken(token: String) extends CoverallsAuth
 
 /** Auth strategy where no token is passed. This seems to work for Travis.
   */

--- a/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsClient.scala
@@ -1,22 +1,21 @@
 package org.scoverage.coveralls
 
-import scala.io.{Codec, Source}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import scalaj.http.{MultiPart, Http}
-import scalaj.http.HttpOptions._
-import java.io.File
-import javax.net.ssl.{SSLSocket, SSLSocketFactory}
-import java.net.{Socket, InetAddress}
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import scalaj.http.HttpOptions._
+import scalaj.http.{Http, MultiPart}
+
+import java.io.File
+import java.net.{InetAddress, Socket}
+import javax.net.ssl.{SSLSocket, SSLSocketFactory}
+import scala.io.{Codec, Source}
 
 class CoverallsClient(endpoint: String, httpClient: HttpClient) {
 
-  import CoverallsClient._
-
-  val mapper = newMapper
+  val mapper: ObjectMapper = newMapper
   def url: String = s"$endpoint/api/v1/jobs"
 
-  def newMapper = {
+  def newMapper: ObjectMapper = {
     val mapper = new ObjectMapper
     mapper.registerModule(DefaultScalaModule)
     mapper
@@ -97,9 +96,10 @@ class ScalaJHttpClient extends HttpClient {
 }
 
 class OpenJdkSafeSsl extends SSLSocketFactory {
-  val child = SSLSocketFactory.getDefault.asInstanceOf[SSLSocketFactory]
+  val child: SSLSocketFactory =
+    SSLSocketFactory.getDefault.asInstanceOf[SSLSocketFactory]
 
-  val safeCiphers = Array(
+  val safeCiphers: Array[String] = Array(
     "SSL_RSA_WITH_RC4_128_MD5",
     "SSL_RSA_WITH_RC4_128_SHA",
     "TLS_RSA_WITH_AES_128_CBC_SHA",
@@ -123,28 +123,32 @@ class OpenJdkSafeSsl extends SSLSocketFactory {
     .asInstanceOf[SSLSocketFactory]
     .getSupportedCipherSuites
 
-  def getDefaultCipherSuites = Array.empty
+  def getDefaultCipherSuites: Array[String] = Array.empty
 
-  def getSupportedCipherSuites = Array.empty
+  def getSupportedCipherSuites: Array[String] = Array.empty
 
-  def createSocket(p1: Socket, p2: String, p3: Int, p4: Boolean) = safeSocket(
-    child.createSocket(p1, p2, p3, p4)
-  )
+  def createSocket(p1: Socket, p2: String, p3: Int, p4: Boolean): Socket =
+    safeSocket(
+      child.createSocket(p1, p2, p3, p4)
+    )
 
-  def createSocket(p1: String, p2: Int) = safeSocket(child.createSocket(p1, p2))
-
-  def createSocket(p1: String, p2: Int, p3: InetAddress, p4: Int) = safeSocket(
-    child.createSocket(p1, p2, p3, p4)
-  )
-
-  def createSocket(p1: InetAddress, p2: Int) = safeSocket(
+  def createSocket(p1: String, p2: Int): Socket = safeSocket(
     child.createSocket(p1, p2)
   )
 
-  def createSocket(p1: InetAddress, p2: Int, p3: InetAddress, p4: Int) =
+  def createSocket(p1: String, p2: Int, p3: InetAddress, p4: Int): Socket =
+    safeSocket(
+      child.createSocket(p1, p2, p3, p4)
+    )
+
+  def createSocket(p1: InetAddress, p2: Int): Socket = safeSocket(
+    child.createSocket(p1, p2)
+  )
+
+  def createSocket(p1: InetAddress, p2: Int, p3: InetAddress, p4: Int): Socket =
     safeSocket(child.createSocket(p1, p2, p3, p4))
 
-  def safeSocket(sock: Socket) = sock match {
+  def safeSocket(sock: Socket): Socket = sock match {
     case ssl: SSLSocket =>
       ssl.setEnabledCipherSuites(safeCiphers); ssl
     case other => other

--- a/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
@@ -1,13 +1,11 @@
 package org.scoverage.coveralls
 
-import _root_.sbt.ScopeFilter
-import _root_.sbt.ThisProject
-import com.fasterxml.jackson.core.JsonEncoding
 import sbt.Keys._
-import sbt._
+import sbt.internal.util.ManagedLogger
+import sbt.{ScopeFilter, ThisProject, _}
 
-import scala.io.Source
 import java.io.File
+import scala.io.Source
 
 object Imports {
   object CoverallsKeys {
@@ -36,8 +34,8 @@ object CoverallsPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   val autoImport = Imports
-  import autoImport._
-  import CoverallsKeys._
+  import autoImport.*
+  import CoverallsKeys.*
 
   lazy val coveralls = taskKey[Unit](
     "Uploads scala code coverage to coveralls.io"
@@ -67,7 +65,7 @@ object CoverallsPlugin extends AutoPlugin {
   ) // must be outside of the 'coverageAggregate' task (see: https://github.com/sbt/sbt/issues/1095 or https://github.com/sbt/sbt/issues/780)
 
   def coverallsTask = Def.task {
-    implicit val log = streams.value.log
+    implicit val log: ManagedLogger = streams.value.log
 
     if (!coberturaFile.value.exists) {
       sys.error(
@@ -167,13 +165,13 @@ object CoverallsPlugin extends AutoPlugin {
     }
   }
 
-  def apiHttpClient = new ScalaJHttpClient
+  def apiHttpClient: ScalaJHttpClient = new ScalaJHttpClient
 
-  def travisJobIdent = sys.env.get("TRAVIS_JOB_ID")
+  def travisJobIdent: Option[String] = sys.env.get("TRAVIS_JOB_ID")
 
-  def githubActionsRunIdent = sys.env.get("GITHUB_RUN_ID")
+  def githubActionsRunIdent: Option[String] = sys.env.get("GITHUB_RUN_ID")
 
-  def repoTokenFromFile(path: String) = {
+  def repoTokenFromFile(path: String): Option[String] = {
     try {
       val source = Source.fromFile(path)
       val repoToken = source.mkString.trim
@@ -187,13 +185,13 @@ object CoverallsPlugin extends AutoPlugin {
   def userRepoToken(
       coverallsToken: Option[String],
       coverallsTokenFile: Option[String]
-  ) =
+  ): Option[String] =
     sys.env
       .get("COVERALLS_REPO_TOKEN")
       .orElse(coverallsToken)
       .orElse(coverallsTokenFile.flatMap(repoTokenFromFile))
 
-  def userEndpoint(coverallsEndpoint: Option[String]) =
+  def userEndpoint(coverallsEndpoint: Option[String]): Option[String] =
     sys.env
       .get("COVERALLS_ENDPOINT")
       .orElse(coverallsEndpoint)

--- a/src/main/scala/org/scoverage/coveralls/GitClient.scala
+++ b/src/main/scala/org/scoverage/coveralls/GitClient.scala
@@ -1,12 +1,14 @@
 package org.scoverage.coveralls
 
-import java.io.File
-import java.nio.file.Files.lines
-
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.{Repository, StoredConfig}
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.scoverage.coveralls.GitClient.GitRevision
 import sbt.Logger
+
+import java.io.File
+import java.nio.file.Files.lines
+import scala.util.matching.Regex
 
 object GitClient {
   case class GitRevision(
@@ -23,11 +25,11 @@ class GitClient(cwd: File)(implicit log: Logger) {
 
   import scala.collection.JavaConverters._
 
-  val gitDirLineRegex = """^gitdir: (.*)""".r
+  val gitDirLineRegex: Regex = """^gitdir: (.*)""".r
 
   val gitFile = new File(cwd, ".git")
 
-  val resolvedGitDir =
+  val resolvedGitDir: File =
     if (gitFile.isFile)
       lines(gitFile.toPath)
         .iterator()
@@ -44,8 +46,8 @@ class GitClient(cwd: File)(implicit log: Logger) {
     else
       gitFile
 
-  val repository = FileRepositoryBuilder.create(resolvedGitDir)
-  val storedConfig = repository.getConfig
+  val repository: Repository = FileRepositoryBuilder.create(resolvedGitDir)
+  val storedConfig: StoredConfig = repository.getConfig
   log.info("Repository = " + repository.getDirectory)
 
   def remotes: Seq[String] = {

--- a/src/main/scala/org/scoverage/coveralls/Utils.scala
+++ b/src/main/scala/org/scoverage/coveralls/Utils.scala
@@ -1,6 +1,7 @@
 package org.scoverage.coveralls
 
 import java.io.File
+import scala.annotation.tailrec
 
 object Utils {
   def mkFileFromPath(path: Seq[String]): File = {
@@ -9,6 +10,7 @@ object Utils {
     mkFileFromPath(new File(p), ps)
   }
 
+  @tailrec
   def mkFileFromPath(base: File, path: Seq[String]): File = path match {
     case p :: ps => mkFileFromPath(new File(base, p), ps)
     case _       => base

--- a/src/main/scala/org/scoverage/coveralls/XmlHelper.scala
+++ b/src/main/scala/org/scoverage/coveralls/XmlHelper.scala
@@ -1,10 +1,9 @@
 package org.scoverage.coveralls
 
-import java.io.{File, FileInputStream}
-import javax.xml.parsers.SAXParserFactory
-
 import org.xml.sax.InputSource
 
+import java.io.{File, FileInputStream}
+import javax.xml.parsers.SAXParserFactory
 import scala.util.Try
 import scala.xml.XML
 

--- a/src/test/scala/org/scoverage/coveralls/CIServiceTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CIServiceTest.scala
@@ -1,11 +1,7 @@
 package org.scoverage.coveralls
 
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-
-import sbt.ConsoleLogger
-
-import scala.Option
+import org.scalatest.wordspec.AnyWordSpec
 
 class CIServiceTest extends AnyWordSpec with Matchers {
 

--- a/src/test/scala/org/scoverage/coveralls/CoberturaMultiSourceReaderTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoberturaMultiSourceReaderTest.scala
@@ -1,17 +1,17 @@
 package org.scoverage.coveralls
 
-import java.io.{FileNotFoundException, File}
-
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Ignore
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import sbt.util.AbstractLogger
+
+import java.io.{File, FileNotFoundException}
 
 class CoberturaMultiSourceReaderTest
     extends AnyWordSpec
     with BeforeAndAfterAll
     with Matchers {
-  implicit val log = sbt.Logger.Null
+  implicit val log: AbstractLogger = sbt.Logger.Null
 
   val resourceDir = Utils.mkFileFromPath(Seq(".", "src", "test", "resources"))
   val sourceDirA =

--- a/src/test/scala/org/scoverage/coveralls/CoverallPayloadWriterTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoverallPayloadWriterTest.scala
@@ -1,17 +1,17 @@
 package org.scoverage.coveralls
 
 import java.io.{File, StringWriter, Writer}
-
 import com.fasterxml.jackson.core.JsonFactory
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
+import sbt.util.AbstractLogger
 
 class CoverallPayloadWriterTest
     extends AnyWordSpec
     with BeforeAndAfterAll
     with Matchers {
-  implicit val log = sbt.Logger.Null
+  implicit val log: AbstractLogger = sbt.Logger.Null
 
   val resourceDir = Utils.mkFileFromPath(Seq(".", "src", "test", "resources"))
 
@@ -71,7 +71,7 @@ class CoverallPayloadWriterTest
           new StringWriter(),
           Some("testRepoToken"),
           Some(testService),
-          false
+          parallel = false
         )
 
         payloadWriter.start()
@@ -92,7 +92,7 @@ class CoverallPayloadWriterTest
             new StringWriter(),
             Some("testRepoToken"),
             None,
-            false
+            parallel = false
           )
 
         payloadWriter.start()
@@ -120,7 +120,7 @@ class CoverallPayloadWriterTest
           new StringWriter(),
           Some("testRepoToken"),
           Some(testService),
-          false
+          parallel = false
         )
 
         payloadWriter.start()
@@ -150,7 +150,7 @@ class CoverallPayloadWriterTest
           new StringWriter(),
           Some("testRepoToken"),
           Some(TravisCI),
-          false
+          parallel = false
         )
         payloadWriter.addSourceFile(
           SourceFileReport(
@@ -190,7 +190,7 @@ class CoverallPayloadWriterTest
           new StringWriter(),
           Some("testRepoToken"),
           Some(TravisCI),
-          false
+          parallel = false
         )
 
         payloadWriter.start()
@@ -201,7 +201,12 @@ class CoverallPayloadWriterTest
 
       "include parallel correctly" in {
         val (payloadWriter, writer) =
-          coverallsWriter(new StringWriter(), Some("testRepoToken"), None, true)
+          coverallsWriter(
+            new StringWriter(),
+            Some("testRepoToken"),
+            None,
+            parallel = true
+          )
 
         payloadWriter.start()
         payloadWriter.flush()

--- a/src/test/scala/org/scoverage/coveralls/CoverallsClientTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/CoverallsClientTest.scala
@@ -1,15 +1,12 @@
 package org.scoverage.coveralls
 
-import java.io.File
-import java.net.HttpURLConnection
-
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
-
-import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scalaj.http.Http
 import scalaj.http.HttpOptions._
+
+import scala.util.Try
 
 class CoverallsClientTest
     extends AnyWordSpec

--- a/src/test/scala/org/scoverage/coveralls/GitClientTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/GitClientTest.scala
@@ -1,19 +1,18 @@
 package org.scoverage.coveralls
 
-import java.io.File
-
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.BeforeAndAfterAll
 import org.eclipse.jgit.api.Git
-
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import sbt.ConsoleLogger
+
+import java.io.File
 
 class GitClientTest extends AnyWordSpec with BeforeAndAfterAll with Matchers {
 
-  implicit val log = ConsoleLogger(System.out)
+  implicit val log: ConsoleLogger = ConsoleLogger(System.out)
 
-  var git: GitClient = null
+  var git: GitClient = _
 
   override def beforeAll(): Unit = {
     // Create local repository

--- a/src/test/scala/org/scoverage/coveralls/UtilsTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/UtilsTest.scala
@@ -1,9 +1,9 @@
 package org.scoverage.coveralls
 
-import java.io.File
-
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
 
 class UtilsTest extends AnyWordSpec with Matchers {
   "mkFileFromPath" when {

--- a/src/test/scala/org/scoverage/coveralls/XmlHelperTest.scala
+++ b/src/test/scala/org/scoverage/coveralls/XmlHelperTest.scala
@@ -1,10 +1,9 @@
 package org.scoverage.coveralls
 
-import java.io.File
-
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
+import java.io.File
 import scala.xml.XML
 
 class XmlHelperTest extends AnyWordSpec with Matchers {


### PR DESCRIPTION
This PR applies easy inspections/fixes found within Intellij + some others i.e.

* Optimizing/reorganizing imports
* Adding types to public methods (this was skipped in tests since its kind of pointless there)
* Adding types to implicit definitions (this is a requirement in Scala 3 and good practice in general)
* Naming boolean parameters
* Making `case class` final (`case class` should really be final by default because overriding a `case class` can break expected that is expected of a `case class`)
* Using `_` initializer instead of `null`
* Adding `@tailrec` for methods which are tail call recursive
* Make traits extend `Product` and `Serializable` to make types nicer (see https://stackoverflow.com/a/36526562)

All in all, none of these changes should be that controversial