### PR TITLE
Fix updating of scala versions with scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,10 @@
-# Latest version of jgit which was compiled with JDK 8 which this project targets
-updates.pin = [{ groupId = "org.eclipse.jgit", version = "5.13.0.202109080827-r" }]
+updates.pin = [
+  # Latest version of jgit which was compiled with JDK 8 which this project targets
+  { groupId = "org.eclipse.jgit", version = "5.13.0.202109080827-r" },
+  # Only do updates for Scala 2.12 series
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]
+
 updates.ignore = [
   { groupId = "org.eclipse.jgit" }
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ inThisBuild(
     licenses := Seq(
       "Apache-2.0" -> url("http://www.apache.org/license/LICENSE-2.0")
     ),
-    scalaVersion := "2.12.17", // scala-steward:off
+    scalaVersion := "2.12.20",
     versionScheme := Some("semver-spec")
   )
 )


### PR DESCRIPTION
`{ groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }` is a trick that you can use so that scala steward only makes updates for the patch updates in the scala 2.12 series and not do things like update Scala 2.12 to 2.13