### PR TITLE
Properly close sources from files

### DIFF
--- a/src/main/scala/org/scoverage/coveralls/CIService.scala
+++ b/src/main/scala/org/scoverage/coveralls/CIService.scala
@@ -4,7 +4,8 @@ import io.circe._
 import io.circe.parser
 import io.circe.generic.auto._
 
-import scala.io.Source
+import scala.io.{BufferedSource, Source}
+import scala.util.control.NonFatal
 
 trait CIService {
   def name: String
@@ -56,11 +57,16 @@ case object GitHubActions extends CIService {
   }
 
   def getPrNumber(payloadPath: String): Option[String] = {
+    var source: BufferedSource = null
     val lines =
       try {
-        Some(Source.fromFile(payloadPath, "utf-8").getLines.mkString)
+        source = Source.fromFile(payloadPath, "utf-8")
+        Some(source.getLines.mkString)
       } catch {
-        case _: Throwable => None
+        case NonFatal(_) => None
+      } finally {
+        if (source != null)
+          source.close()
       }
 
     lines match {

--- a/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
+++ b/src/main/scala/org/scoverage/coveralls/CoverallsPlugin.scala
@@ -5,7 +5,8 @@ import sbt.internal.util.ManagedLogger
 import sbt.{ScopeFilter, ThisProject, _}
 
 import java.io.File
-import scala.io.Source
+import scala.io.{BufferedSource, Source}
+import scala.util.control.NonFatal
 
 object Imports {
   object CoverallsKeys {
@@ -172,13 +173,17 @@ object CoverallsPlugin extends AutoPlugin {
   def githubActionsRunIdent: Option[String] = sys.env.get("GITHUB_RUN_ID")
 
   def repoTokenFromFile(path: String): Option[String] = {
+    var source: BufferedSource = null
     try {
-      val source = Source.fromFile(path)
+      source = Source.fromFile(path)
       val repoToken = source.mkString.trim
       source.close()
       Some(repoToken)
     } catch {
-      case _: Exception => None
+      case NonFatal(_) => None
+    } finally {
+      if (source != null)
+        source.close()
     }
   }
 


### PR DESCRIPTION
Intellij picked this up when inspecting the codebase, there are a lot of cases of creating a `BufferedSource` from a file using `scala.io.Source` but not properly closing the file in all cases (i.e. if there is an exception) which can lead to file handle leaks.

As another improvement, we use `scala.util.control.NonFatal` since when you catch exceptions you should only be catching the ones that make sense to catch.